### PR TITLE
feat: Add dynamic container images with pattern allowlist

### DIFF
--- a/cmd/stromboli/main.go
+++ b/cmd/stromboli/main.go
@@ -111,12 +111,19 @@ func main() {
 		Timeout: cfg.Resources.Timeout,
 	}
 
-	podmanRunner, err := runner.NewPodmanRunnerWithDefaults(
+	imageConfig := runner.ImageConfig{
+		AllowedPatterns: cfg.Agent.AllowedImagePatterns,
+		MountClaudeCLI:  cfg.Agent.MountClaudeCLI,
+	}
+
+	podmanRunner, err := runner.NewPodmanRunnerFull(
 		fullImage,
 		cfg.Agent.CredentialsFile,
 		cfg.Agent.SessionsDir,
 		allowedWorkspaces,
 		resourceDefaults,
+		imageConfig,
+		runner.NewShellExecutor(),
 	)
 	if err != nil {
 		slog.Error("Failed to create runner", "error", err)
@@ -127,6 +134,12 @@ func main() {
 		"memory", cfg.Resources.Memory,
 		"cpus", cfg.Resources.CPUs,
 		"timeout", cfg.Resources.Timeout)
+
+	if len(cfg.Agent.AllowedImagePatterns) > 0 {
+		slog.Info("Dynamic images enabled",
+			"allowed_patterns", cfg.Agent.AllowedImagePatterns,
+			"mount_claude_cli", cfg.Agent.MountClaudeCLI)
+	}
 
 	// Cleanup orphaned containers from previous runs
 	slog.Info("Cleaning up orphaned containers...")

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1476,6 +1476,11 @@ const docTemplate = `{
                     "type": "string",
                     "example": "1"
                 },
+                "image": {
+                    "description": "Container image override (must match allowed patterns)",
+                    "type": "string",
+                    "example": "python:3.12"
+                },
                 "memory": {
                     "description": "Memory limit (e.g., \"512m\", \"1g\")",
                     "type": "string",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1470,6 +1470,11 @@
                     "type": "string",
                     "example": "1"
                 },
+                "image": {
+                    "description": "Container image override (must match allowed patterns)",
+                    "type": "string",
+                    "example": "python:3.12"
+                },
                 "memory": {
                     "description": "Memory limit (e.g., \"512m\", \"1g\")",
                     "type": "string",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -596,6 +596,10 @@ definitions:
         description: CPU limit (e.g., "0.5", "2")
         example: "1"
         type: string
+      image:
+        description: Container image override (must match allowed patterns)
+        example: python:3.12
+        type: string
       memory:
         description: Memory limit (e.g., "512m", "1g")
         example: 512m

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,11 +32,13 @@ type ServerConfig struct {
 
 // AgentConfig holds agent container configuration
 type AgentConfig struct {
-	Image           string           // Container image name
-	ImageTag        string           // Container image tag
-	CredentialsFile string           // Path to Claude credentials file (~/.claude/.credentials.json)
-	SessionsDir     string           // Directory for session data
-	TokenCache      TokenCacheConfig // Token cache configuration
+	Image                string           // Container image name (default)
+	ImageTag             string           // Container image tag
+	AllowedImagePatterns []string         // Allowed image patterns (e.g., "python:*", "golang:*")
+	MountClaudeCLI       bool             // Mount claude-cli volume into containers
+	CredentialsFile      string           // Path to Claude credentials file (~/.claude/.credentials.json)
+	SessionsDir          string           // Directory for session data
+	TokenCache           TokenCacheConfig // Token cache configuration
 }
 
 // TokenCacheConfig holds token caching configuration
@@ -152,6 +154,8 @@ func setupViper(v *viper.Viper) {
 	v.SetDefault("server.address", defaultServerAddress)
 	v.SetDefault("agent.image", defaultAgentImage)
 	v.SetDefault("agent.image_tag", defaultAgentImageTag)
+	v.SetDefault("agent.allowed_image_patterns", []string{})
+	v.SetDefault("agent.mount_claude_cli", false)
 	v.SetDefault("agent.credentials_file", defaultCredentialsFile)
 	v.SetDefault("agent.sessions_dir", defaultSessionsDir)
 	v.SetDefault("agent.token_cache.enabled", true)
@@ -184,6 +188,8 @@ func setupViper(v *viper.Viper) {
 	_ = v.BindEnv("server.address", "STROMBOLI_SERVER_ADDRESS")
 	_ = v.BindEnv("agent.image", "STROMBOLI_AGENT_IMAGE")
 	_ = v.BindEnv("agent.image_tag", "STROMBOLI_AGENT_IMAGE_TAG")
+	_ = v.BindEnv("agent.allowed_image_patterns", "STROMBOLI_AGENT_ALLOWED_IMAGE_PATTERNS")
+	_ = v.BindEnv("agent.mount_claude_cli", "STROMBOLI_AGENT_MOUNT_CLAUDE_CLI")
 	_ = v.BindEnv("agent.credentials_file", "STROMBOLI_AGENT_CREDENTIALS_FILE")
 	_ = v.BindEnv("agent.sessions_dir", "STROMBOLI_AGENT_SESSIONS_DIR")
 	_ = v.BindEnv("agent.token_cache.enabled", "STROMBOLI_TOKEN_CACHE_ENABLED")
@@ -220,10 +226,12 @@ func parseConfig(v *viper.Viper) (*Config, error) {
 			Address: v.GetString("server.address"),
 		},
 		Agent: AgentConfig{
-			Image:           v.GetString("agent.image"),
-			ImageTag:        v.GetString("agent.image_tag"),
-			CredentialsFile: v.GetString("agent.credentials_file"),
-			SessionsDir:     v.GetString("agent.sessions_dir"),
+			Image:                v.GetString("agent.image"),
+			ImageTag:             v.GetString("agent.image_tag"),
+			AllowedImagePatterns: v.GetStringSlice("agent.allowed_image_patterns"),
+			MountClaudeCLI:       v.GetBool("agent.mount_claude_cli"),
+			CredentialsFile:      v.GetString("agent.credentials_file"),
+			SessionsDir:          v.GetString("agent.sessions_dir"),
 			TokenCache: TokenCacheConfig{
 				Enabled: v.GetBool("agent.token_cache.enabled"),
 				TTL:     cacheTTL,

--- a/internal/runner/image.go
+++ b/internal/runner/image.go
@@ -1,0 +1,107 @@
+package runner
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ClaudeCLIVolumeName is the name of the Podman volume containing Claude CLI
+const ClaudeCLIVolumeName = "claude-cli"
+
+// ClaudeCLIPath is where Claude CLI is mounted inside containers
+const ClaudeCLIPath = "/usr/local/bin"
+
+// ImageValidator validates container images against allowed patterns
+type ImageValidator struct {
+	patterns     []string
+	defaultImage string
+}
+
+// NewImageValidator creates a new image validator
+func NewImageValidator(allowedPatterns []string, defaultImage string) *ImageValidator {
+	return &ImageValidator{
+		patterns:     allowedPatterns,
+		defaultImage: defaultImage,
+	}
+}
+
+// Validate checks if an image is allowed
+func (v *ImageValidator) Validate(image string) error {
+	if image == "" {
+		return nil // Empty means use default
+	}
+
+	if !v.IsAllowed(image) {
+		return fmt.Errorf("image %q not in allowed patterns", image)
+	}
+
+	return nil
+}
+
+// IsAllowed checks if an image matches any allowed pattern
+func (v *ImageValidator) IsAllowed(image string) bool {
+	// If no patterns configured, allow all (backward compatible)
+	if len(v.patterns) == 0 {
+		return true
+	}
+
+	for _, pattern := range v.patterns {
+		if matchImagePattern(pattern, image) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Resolve returns the image to use (request image or default)
+func (v *ImageValidator) Resolve(requestImage string) string {
+	if requestImage != "" {
+		return requestImage
+	}
+	return v.defaultImage
+}
+
+// matchImagePattern matches an image against a pattern
+// Supports glob patterns: * matches any sequence of characters
+func matchImagePattern(pattern, image string) bool {
+	// Normalize: add docker.io/library/ prefix if no registry specified
+	normalizedImage := normalizeImageName(image)
+	normalizedPattern := normalizeImageName(pattern)
+
+	// Try exact match first
+	if normalizedPattern == normalizedImage {
+		return true
+	}
+
+	// Try glob match
+	matched, _ := filepath.Match(normalizedPattern, normalizedImage)
+	if matched {
+		return true
+	}
+
+	// Try matching without normalization (for explicit patterns)
+	matched, _ = filepath.Match(pattern, image)
+	return matched
+}
+
+// normalizeImageName adds default registry/library if not specified
+func normalizeImageName(image string) string {
+	// Already has registry
+	if strings.Contains(image, "/") && (strings.Contains(strings.Split(image, "/")[0], ".") || strings.Contains(strings.Split(image, "/")[0], ":")) {
+		return image
+	}
+
+	// Has library but no registry (e.g., library/python)
+	if strings.HasPrefix(image, "library/") {
+		return "docker.io/" + image
+	}
+
+	// Just image name (e.g., python:3.12)
+	if !strings.Contains(image, "/") {
+		return "docker.io/library/" + image
+	}
+
+	return image
+}

--- a/internal/runner/image_test.go
+++ b/internal/runner/image_test.go
@@ -1,0 +1,144 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImageValidator_IsAllowed(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		image    string
+		expected bool
+	}{
+		{
+			name:     "no patterns allows all",
+			patterns: []string{},
+			image:    "anything:latest",
+			expected: true,
+		},
+		{
+			name:     "exact match",
+			patterns: []string{"python:3.12"},
+			image:    "python:3.12",
+			expected: true,
+		},
+		{
+			name:     "wildcard tag",
+			patterns: []string{"python:*"},
+			image:    "python:3.12",
+			expected: true,
+		},
+		{
+			name:     "wildcard image",
+			patterns: []string{"docker.io/library/*"},
+			image:    "docker.io/library/python:3.12",
+			expected: true,
+		},
+		{
+			name:     "short name matches docker.io pattern",
+			patterns: []string{"docker.io/library/*"},
+			image:    "python:3.12",
+			expected: true,
+		},
+		{
+			name:     "golang pattern",
+			patterns: []string{"golang:*"},
+			image:    "golang:1.22",
+			expected: true,
+		},
+		{
+			name:     "not allowed",
+			patterns: []string{"python:*"},
+			image:    "golang:1.22",
+			expected: false,
+		},
+		{
+			name:     "private registry allowed",
+			patterns: []string{"ghcr.io/myorg/*"},
+			image:    "ghcr.io/myorg/myimage:v1",
+			expected: true,
+		},
+		{
+			name:     "stromboli-agent pattern",
+			patterns: []string{"stromboli-agent*"},
+			image:    "stromboli-agent:latest",
+			expected: true,
+		},
+		{
+			name:     "stromboli-agent-go pattern",
+			patterns: []string{"stromboli-agent*"},
+			image:    "stromboli-agent-go:1.22",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewImageValidator(tt.patterns, "default:latest")
+			result := v.IsAllowed(tt.image)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestImageValidator_Validate(t *testing.T) {
+	v := NewImageValidator([]string{"python:*", "golang:*"}, "python:3.12")
+
+	t.Run("empty image is valid (uses default)", func(t *testing.T) {
+		err := v.Validate("")
+		assert.NoError(t, err)
+	})
+
+	t.Run("allowed image is valid", func(t *testing.T) {
+		err := v.Validate("python:3.11")
+		assert.NoError(t, err)
+	})
+
+	t.Run("disallowed image returns error", func(t *testing.T) {
+		err := v.Validate("rust:latest")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not in allowed patterns")
+	})
+}
+
+func TestImageValidator_Resolve(t *testing.T) {
+	v := NewImageValidator([]string{}, "default:latest")
+
+	t.Run("returns request image when provided", func(t *testing.T) {
+		result := v.Resolve("custom:v1")
+		assert.Equal(t, "custom:v1", result)
+	})
+
+	t.Run("returns default when request empty", func(t *testing.T) {
+		result := v.Resolve("")
+		assert.Equal(t, "default:latest", result)
+	})
+}
+
+func TestNormalizeImageName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"python:3.12", "docker.io/library/python:3.12"},
+		{"library/python:3.12", "docker.io/library/python:3.12"},
+		{"docker.io/library/python:3.12", "docker.io/library/python:3.12"},
+		{"ghcr.io/org/image:v1", "ghcr.io/org/image:v1"},
+		{"localhost:5000/myimage:latest", "localhost:5000/myimage:latest"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := normalizeImageName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConstants(t *testing.T) {
+	assert.Equal(t, "claude-cli", ClaudeCLIVolumeName)
+	assert.Equal(t, "/usr/local/bin", ClaudeCLIPath)
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -58,12 +58,20 @@ type ResourceDefaults struct {
 	Timeout string
 }
 
+// ImageConfig contains image-related configuration
+type ImageConfig struct {
+	AllowedPatterns []string // Allowed image patterns (empty = allow all)
+	MountClaudeCLI  bool     // Mount claude-cli volume into containers
+}
+
 // PodmanRunner runs Claude using Podman containers
 type PodmanRunner struct {
 	image              string
 	secretsMgr         *secrets.Manager
 	sessionMgr         *session.Manager
 	workspaceValidator *workspace.Validator
+	imageValidator     *ImageValidator
+	mountClaudeCLI     bool
 	defaults           ResourceDefaults
 	executor           Executor
 }
@@ -89,6 +97,11 @@ func NewPodmanRunnerWithDefaults(image, secretsFile, sessionsDir string, allowed
 // NewPodmanRunnerWithDefaultsAndExecutor creates a new Podman-based runner with default resource limits and custom executor
 // This is the most flexible constructor, primarily useful for testing
 func NewPodmanRunnerWithDefaultsAndExecutor(image, credentialsFile, sessionsDir string, allowedWorkspaces []string, defaults ResourceDefaults, executor Executor) (*PodmanRunner, error) {
+	return NewPodmanRunnerFull(image, credentialsFile, sessionsDir, allowedWorkspaces, defaults, ImageConfig{}, executor)
+}
+
+// NewPodmanRunnerFull creates a new Podman-based runner with all configuration options
+func NewPodmanRunnerFull(image, credentialsFile, sessionsDir string, allowedWorkspaces []string, defaults ResourceDefaults, imageConfig ImageConfig, executor Executor) (*PodmanRunner, error) {
 	// Create secrets manager and ensure credentials exist + Podman secret is created
 	secretsMgr := secrets.NewManagerWithPath(credentialsFile)
 	if err := secretsMgr.EnsureExists(context.Background(), ""); err != nil {
@@ -100,6 +113,8 @@ func NewPodmanRunnerWithDefaultsAndExecutor(image, credentialsFile, sessionsDir 
 		secretsMgr:         secretsMgr,
 		sessionMgr:         session.NewManager(sessionsDir),
 		workspaceValidator: workspace.NewValidator(allowedWorkspaces),
+		imageValidator:     NewImageValidator(imageConfig.AllowedPatterns, image),
+		mountClaudeCLI:     imageConfig.MountClaudeCLI,
 		defaults:           defaults,
 		executor:           executor,
 	}, nil
@@ -131,6 +146,12 @@ func (r *PodmanRunner) Run(ctx context.Context, req Request) (*Result, error) {
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
+
+	// Validate and resolve container image
+	if err := r.imageValidator.Validate(req.Podman.Image); err != nil {
+		return nil, fmt.Errorf("image validation failed: %w", err)
+	}
+	containerImage := r.imageValidator.Resolve(req.Podman.Image)
 
 	// Create or get session directory
 	sessionID, absSessionPath, err := r.sessionMgr.Create(req.Claude.SessionID)
@@ -164,7 +185,12 @@ func (r *PodmanRunner) Run(ctx context.Context, req Request) (*Result, error) {
 		WithKeepID().
 		WithUser(currentUser).
 		WithEnv("HOME", "/home/user").
-		WithImage(r.image)
+		WithImage(containerImage)
+
+	// Mount Claude CLI volume if configured (for dynamic images)
+	if r.mountClaudeCLI {
+		podmanBuilder.WithVolumeRaw(ClaudeCLIVolumeName + ":" + ClaudeCLIPath + ":ro")
+	}
 
 	// SESSION ISOLATION: Mount session-specific directory as user's home
 	// Each session gets its own persistent storage at /home/user
@@ -287,6 +313,12 @@ func (r *PodmanRunner) RunStream(ctx context.Context, req Request, output chan<-
 		defer cancel()
 	}
 
+	// Validate and resolve container image
+	if err := r.imageValidator.Validate(req.Podman.Image); err != nil {
+		return nil, fmt.Errorf("image validation failed: %w", err)
+	}
+	containerImage := r.imageValidator.Resolve(req.Podman.Image)
+
 	// Create or get session directory
 	sessionID, absSessionPath, err := r.sessionMgr.Create(req.Claude.SessionID)
 	if err != nil {
@@ -316,7 +348,12 @@ func (r *PodmanRunner) RunStream(ctx context.Context, req Request, output chan<-
 		WithKeepID().
 		WithUser(currentUser).
 		WithEnv("HOME", "/home/user").
-		WithImage(r.image)
+		WithImage(containerImage)
+
+	// Mount Claude CLI volume if configured (for dynamic images)
+	if r.mountClaudeCLI {
+		podmanBuilder.WithVolumeRaw(ClaudeCLIVolumeName + ":" + ClaudeCLIPath + ":ro")
+	}
 
 	// Mount session-specific directory as user's home
 	podmanBuilder.WithVolume(absSessionPath, "/home/user")

--- a/internal/types/options.go
+++ b/internal/types/options.go
@@ -117,6 +117,9 @@ type ClaudeOptions struct {
 // PodmanOptions contains Podman container configuration
 // @Description Podman container mount configuration
 type PodmanOptions struct {
+	// Container image override (must match allowed patterns)
+	Image string `json:"image,omitempty" example:"python:3.12"`
+
 	// Volume mounts (host:container or host:container:options format)
 	Volumes []string `json:"volumes,omitempty" example:"/data:/data:ro"`
 


### PR DESCRIPTION
## Summary
- 🐳 Add ImageValidator with glob pattern matching for allowed images (e.g., `python:*`, `golang:*`)
- 📦 Support claude-cli volume mounting for non-default images
- ⚙️ Add `Image` field to PodmanOptions for runtime image selection

## Configuration
```yaml
agent:
  allowed_image_patterns:
    - "python:*"
    - "golang:*"
    - "node:*"
  mount_claude_cli: true  # Mount claude-cli volume for custom images
```

## Test plan
- [x] Unit tests for ImageValidator pattern matching
- [x] Tests for image name normalization (docker.io/library/ prefix)
- [ ] E2E test with custom Python image
- [ ] E2E test with custom Go image

🤖 Generated with [Claude Code](https://claude.com/claude-code)