### PR TITLE
docs: Add MkDocs documentation site with Material theme

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,68 @@
+name: Deploy Documentation
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g., 0.1.5)'
+        required: true
+      set_latest:
+        description: 'Set as latest version'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material mike
+
+      - name: Extract version from tag
+        if: github.event_name == 'push'
+        id: tag_version
+        run: |
+          # Extract version from tag (v0.1.5-alpha -> 0.1.5)
+          TAG=${GITHUB_REF#refs/tags/v}
+          VERSION=$(echo $TAG | sed 's/-alpha//' | sed 's/-beta//' | sed 's/-rc.*//')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Deploy docs (from tag)
+        if: github.event_name == 'push'
+        run: |
+          mike deploy --push --update-aliases ${{ steps.tag_version.outputs.version }} latest
+          mike set-default --push latest
+
+      - name: Deploy docs (manual)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ inputs.set_latest }}" == "true" ]; then
+            mike deploy --push --update-aliases ${{ inputs.version }} latest
+            mike set-default --push latest
+          else
+            mike deploy --push ${{ inputs.version }}
+          fi

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,34 @@
+name: Documentation Preview
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material mike
+
+      - name: Build docs
+        run: |
+          mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-preview
+          path: site/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ tmp/
 # Go build cache (from containerized builds)
 .cache/
 .config/
+
+# MkDocs build output
+site/

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -1,0 +1,185 @@
+# Authentication
+
+Stromboli supports JWT-based authentication for securing the API.
+
+## Enabling Authentication
+
+Set the required environment variables:
+
+```bash
+export STROMBOLI_AUTH_ENABLED=true
+export STROMBOLI_AUTH_JWT_SECRET="your-secure-256-bit-secret"
+export STROMBOLI_AUTH_API_TOKEN="your-api-token-for-generating-jwts"
+```
+
+## Authentication Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Stromboli
+
+    Client->>Stromboli: POST /auth/token (API Token)
+    Stromboli->>Client: {access_token, refresh_token}
+
+    Client->>Stromboli: POST /run (Bearer access_token)
+    Stromboli->>Client: {output: "..."}
+
+    Note over Client,Stromboli: When access token expires...
+
+    Client->>Stromboli: POST /auth/refresh (refresh_token)
+    Stromboli->>Client: {new access_token, new refresh_token}
+```
+
+## Generating Tokens
+
+### POST /auth/token
+
+Exchange your API token for JWT tokens.
+
+**Request:**
+```bash
+curl -X POST http://localhost:8080/auth/token \
+  -H "Authorization: Bearer your-api-token" \
+  -H "Content-Type: application/json" \
+  -d '{"client_id": "my-app"}'
+```
+
+**Response:**
+```json
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIs...",
+  "refresh_token": "eyJhbGciOiJIUzI1NiIs...",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+```
+
+## Using Tokens
+
+Include the access token in the `Authorization` header:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIs..." \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Hello"}'
+```
+
+## Refreshing Tokens
+
+### POST /auth/refresh
+
+Get new tokens using a refresh token.
+
+**Request:**
+```bash
+curl -X POST http://localhost:8080/auth/refresh \
+  -H "Content-Type: application/json" \
+  -d '{"refresh_token": "eyJhbGciOiJIUzI1NiIs..."}'
+```
+
+**Response:**
+```json
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIs...",
+  "refresh_token": "eyJhbGciOiJIUzI1NiIs...",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+```
+
+## Validating Tokens
+
+### POST /auth/validate
+
+Check if a token is valid.
+
+**Request:**
+```bash
+curl -X POST http://localhost:8080/auth/validate \
+  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIs..."
+```
+
+**Response:**
+```json
+{
+  "valid": true,
+  "claims": {
+    "sub": "my-app",
+    "exp": 1640000000,
+    "iat": 1639996400
+  }
+}
+```
+
+## Logging Out
+
+### POST /auth/logout
+
+Invalidate a token (adds to blacklist).
+
+**Request:**
+```bash
+curl -X POST http://localhost:8080/auth/logout \
+  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIs..."
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Token invalidated"
+}
+```
+
+## Token Lifetimes
+
+| Token Type | Lifetime | Configurable |
+|------------|----------|--------------|
+| Access Token | 1 hour | Not yet |
+| Refresh Token | 7 days | Not yet |
+
+## Security Best Practices
+
+### 1. Use Strong Secrets
+
+```bash
+# Generate a secure secret
+openssl rand -base64 32
+```
+
+### 2. Store Tokens Securely
+
+- Never log tokens
+- Don't store in localStorage for web apps
+- Use secure, HTTP-only cookies when possible
+
+### 3. Rotate Secrets Periodically
+
+Change `STROMBOLI_AUTH_JWT_SECRET` periodically:
+1. Add new secret
+2. Accept both old and new
+3. Remove old secret
+
+### 4. Use HTTPS in Production
+
+Always use TLS/SSL to protect tokens in transit.
+
+## Public Endpoints
+
+These endpoints don't require authentication:
+
+- `GET /health` - Health check
+- `GET /metrics` - Prometheus metrics
+- `POST /auth/token` - Token generation (requires API token)
+- `POST /auth/refresh` - Token refresh
+
+## Error Responses
+
+| Status | Error | Description |
+|--------|-------|-------------|
+| 401 | `token required` | No token provided |
+| 401 | `invalid token` | Token is malformed or invalid |
+| 401 | `token expired` | Token has expired |
+| 401 | `token blacklisted` | Token was invalidated |

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1,0 +1,307 @@
+# API Endpoints
+
+Complete reference for all Stromboli API endpoints.
+
+## POST /run
+
+Run Claude synchronously.
+
+### Request
+
+```json
+{
+  "prompt": "Your prompt here",
+  "workspace": "/path/to/workspace",
+  "webhook_url": "https://...",
+  "claude": {
+    "session_id": "uuid",
+    "resume": false,
+    "continue": false,
+    "fork_session": false,
+    "no_persistence": false,
+    "model": "sonnet",
+    "fallback_model": "haiku",
+    "system_prompt": "...",
+    "append_system_prompt": "...",
+    "tools": ["Bash", "Read"],
+    "allowed_tools": ["Bash(git:*)"],
+    "disallowed_tools": ["Write"],
+    "permission_mode": "default",
+    "dangerously_skip_permissions": false,
+    "input_format": "text",
+    "output_format": "json",
+    "max_budget_usd": 5.00,
+    "verbose": false
+  },
+  "podman": {
+    "image": "python:3.12",
+    "volumes": ["/data:/data:ro"],
+    "secrets_env": {"GH_TOKEN": "github-token"},
+    "timeout": "5m",
+    "memory": "512m",
+    "cpus": "1",
+    "cpu_shares": 512
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "id": "run-abc123def456",
+  "status": "completed",
+  "output": "Claude's response...",
+  "session_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### Errors
+
+| Status | Error |
+|--------|-------|
+| 400 | Invalid request body |
+| 400 | Workspace validation failed |
+| 400 | Image validation failed |
+| 503 | Claude not configured |
+| 500 | Execution failed |
+
+---
+
+## GET /run/stream
+
+Run Claude with Server-Sent Events streaming.
+
+### Query Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `prompt` | string | Required. The prompt |
+| `workspace` | string | Workspace path |
+| `session_id` | string | Session to resume |
+| `resume` | bool | Resume session |
+
+### Response
+
+```
+Content-Type: text/event-stream
+
+data: {"type":"output","content":"Hello..."}
+data: {"type":"output","content":"I found..."}
+data: {"type":"done","session_id":"...","id":"run-..."}
+```
+
+---
+
+## POST /run/async
+
+Run Claude asynchronously.
+
+### Request
+
+Same as `/run`.
+
+### Response
+
+```json
+{
+  "job_id": "job-abc123",
+  "status": "pending"
+}
+```
+
+---
+
+## GET /jobs
+
+List all jobs.
+
+### Response
+
+```json
+{
+  "jobs": [
+    {
+      "id": "job-abc123",
+      "status": "completed",
+      "created_at": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+## GET /jobs/:id
+
+Get job details.
+
+### Response
+
+```json
+{
+  "id": "job-abc123",
+  "status": "completed",
+  "output": "...",
+  "session_id": "...",
+  "created_at": "...",
+  "completed_at": "..."
+}
+```
+
+### Job Status Values
+
+| Status | Description |
+|--------|-------------|
+| `pending` | Queued, not started |
+| `running` | Currently executing |
+| `completed` | Finished successfully |
+| `failed` | Finished with error |
+| `cancelled` | Cancelled by user |
+
+---
+
+## DELETE /jobs/:id
+
+Cancel a running or pending job.
+
+### Response
+
+```json
+{
+  "id": "job-abc123",
+  "status": "cancelled"
+}
+```
+
+---
+
+## GET /sessions
+
+List all session IDs.
+
+### Response
+
+```json
+{
+  "sessions": [
+    "550e8400-e29b-41d4-a716-446655440000",
+    "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+  ]
+}
+```
+
+---
+
+## DELETE /sessions/:id
+
+Delete a session and its data.
+
+### Response
+
+```json
+{
+  "success": true,
+  "session_id": "550e8400..."
+}
+```
+
+---
+
+## GET /sessions/:id/messages
+
+Get conversation messages from a session.
+
+### Query Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | int | 50 | Max messages |
+| `offset` | int | 0 | Skip messages |
+
+### Response
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello"
+    },
+    {
+      "role": "assistant",
+      "content": "Hi there!"
+    }
+  ],
+  "total": 2
+}
+```
+
+---
+
+## GET /health
+
+Health check with component status.
+
+### Response
+
+```json
+{
+  "status": "ok",
+  "name": "stromboli",
+  "version": "0.1.5-alpha",
+  "components": [
+    {"name": "podman", "status": "ok"},
+    {"name": "claude-credentials-file", "status": "ok"},
+    {"name": "claude-credentials-secret", "status": "ok"}
+  ]
+}
+```
+
+---
+
+## GET /secrets
+
+List available Podman secrets.
+
+### Response
+
+```json
+{
+  "secrets": [
+    "claude-credentials",
+    "github-token",
+    "gitlab-token"
+  ]
+}
+```
+
+---
+
+## GET /claude/status
+
+Check if Claude credentials are configured.
+
+### Response
+
+```json
+{
+  "configured": true,
+  "message": "Claude is configured"
+}
+```
+
+---
+
+## GET /metrics
+
+Prometheus metrics endpoint.
+
+### Response
+
+```
+# HELP stromboli_active_containers Current number of running containers
+# TYPE stromboli_active_containers gauge
+stromboli_active_containers 2
+...
+```

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,0 +1,131 @@
+# API Overview
+
+Stromboli exposes a REST API for managing Claude agents.
+
+## Base URL
+
+```
+http://localhost:8080
+```
+
+## Authentication
+
+Authentication is optional. When enabled, use JWT tokens:
+
+```bash
+curl -H "Authorization: Bearer <token>" http://localhost:8080/run
+```
+
+See [Authentication](authentication.md) for details.
+
+## Endpoints Summary
+
+### System
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/health` | Health check with component status |
+| GET | `/metrics` | Prometheus metrics |
+| GET | `/claude/status` | Claude credentials status |
+| GET | `/secrets` | List available Podman secrets |
+
+### Execution
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/run` | Run Claude synchronously |
+| GET | `/run/stream` | Run with streaming output |
+| POST | `/run/async` | Run asynchronously |
+
+### Jobs
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/jobs` | List all jobs |
+| GET | `/jobs/:id` | Get job status |
+| DELETE | `/jobs/:id` | Cancel a job |
+
+### Sessions
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/sessions` | List all sessions |
+| DELETE | `/sessions/:id` | Delete a session |
+| GET | `/sessions/:id/messages` | Get session messages |
+
+### Authentication
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/auth/token` | Generate JWT tokens |
+| POST | `/auth/refresh` | Refresh access token |
+| POST | `/auth/validate` | Validate a token |
+| POST | `/auth/logout` | Invalidate a token |
+
+## Request Format
+
+All POST endpoints accept JSON:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Hello",
+    "workspace": "/path/to/project",
+    "claude": { ... },
+    "podman": { ... }
+  }'
+```
+
+## Response Format
+
+Successful responses:
+```json
+{
+  "id": "run-abc123",
+  "status": "completed",
+  "output": "...",
+  "session_id": "..."
+}
+```
+
+Error responses:
+```json
+{
+  "error": "Error message",
+  "status": "error"
+}
+```
+
+## HTTP Status Codes
+
+| Code | Description |
+|------|-------------|
+| 200 | Success |
+| 400 | Bad request (invalid input) |
+| 401 | Unauthorized (auth required) |
+| 404 | Not found |
+| 429 | Rate limited |
+| 500 | Internal server error |
+| 503 | Service unavailable (Claude not configured) |
+
+## Rate Limiting
+
+When enabled, rate limits are applied per IP:
+
+- Default: 10 requests/second
+- Burst: 20 requests
+
+Rate limit headers:
+```
+X-RateLimit-Limit: 10
+X-RateLimit-Remaining: 9
+X-RateLimit-Reset: 1640000000
+```
+
+## OpenAPI Spec
+
+The OpenAPI specification is available at:
+```
+http://localhost:8080/swagger/doc.json
+```

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <!-- Volcano body -->
+  <polygon points="50,15 85,85 15,85" fill="#7c4dff" opacity="0.9"/>
+
+  <!-- Volcano crater -->
+  <ellipse cx="50" cy="20" rx="12" ry="5" fill="#311b92"/>
+
+  <!-- Lava glow -->
+  <ellipse cx="50" cy="18" rx="8" ry="3" fill="#ff6e40"/>
+
+  <!-- Eruption particles -->
+  <circle cx="45" cy="8" r="3" fill="#ffab40"/>
+  <circle cx="55" cy="5" r="2.5" fill="#ff6e40"/>
+  <circle cx="50" cy="2" r="2" fill="#ffab40"/>
+  <circle cx="42" cy="3" r="1.5" fill="#ff8a65"/>
+  <circle cx="58" cy="9" r="2" fill="#ff8a65"/>
+</svg>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to Stromboli will be documented here.
+
+## [0.1.5-alpha] - 2025-01-26
+
+### Added
+- **Credentials Sync**: Automatic synchronization of Claude credentials with Podman secrets
+- **Generic Secrets Injection**: Mount Podman secrets as environment variables via `secrets_env`
+- **Input Validation**: Comprehensive validation for secrets environment variables
+- **/secrets Endpoint**: List available Podman secrets via API
+
+### Security
+- Block dangerous environment variables (LD_PRELOAD, LD_LIBRARY_PATH)
+- Environment variable name validation (must match `^[a-zA-Z_][a-zA-Z0-9_]*$`)
+- Maximum 50 secrets per request
+
+## [0.1.4-alpha] - 2025-01-25
+
+### Added
+- **Dynamic Container Images**: Support for multiple container images with pattern allowlist
+- **Version Info**: `/version` endpoint and startup version logging
+- **Container Naming**: Unique container names with `stromboli-` prefix
+- **Orphan Cleanup**: Automatic cleanup of orphaned containers on startup
+
+### Fixed
+- Version injection into Docker server image during build
+
+## [0.1.3-alpha] - 2025-01-24
+
+### Added
+- Initial public release
+- Core API for running Claude Code agents
+- Session management (create, resume, destroy)
+- Async job execution with polling
+- Workspace mounting with allowlist security
+- JWT authentication support
+- Rate limiting middleware
+- Health check endpoint
+
+### Security
+- Container isolation via Podman
+- Workspace allowlist validation
+- Read-only credential mounting

--- a/docs/deployment/compose.md
+++ b/docs/deployment/compose.md
@@ -1,0 +1,205 @@
+# Docker Compose Deployment
+
+The recommended way to deploy Stromboli.
+
+## Quick Start
+
+```bash
+git clone https://github.com/tomblancdev/stromboli
+cd stromboli
+docker compose up -d
+```
+
+## docker-compose.yml
+
+```yaml
+version: '3.8'
+
+services:
+  stromboli:
+    image: ghcr.io/tomblancdev/stromboli:latest
+    # Or build from source:
+    # build:
+    #   context: .
+    #   dockerfile: deployments/docker/Dockerfile.server
+    ports:
+      - "8080:8080"
+    environment:
+      # Server
+      - STROMBOLI_PORT=8080
+
+      # Agent
+      - STROMBOLI_AGENT_ALLOWED_WORKSPACES=/workspace
+      - STROMBOLI_AGENT_DEFAULT_MEMORY=512m
+      - STROMBOLI_AGENT_DEFAULT_TIMEOUT=5m
+
+      # Optional: Authentication
+      # - STROMBOLI_AUTH_ENABLED=true
+      # - STROMBOLI_AUTH_JWT_SECRET=${JWT_SECRET}
+      # - STROMBOLI_AUTH_API_TOKEN=${API_TOKEN}
+
+      # Optional: Rate Limiting
+      # - STROMBOLI_RATELIMIT_ENABLED=true
+      # - STROMBOLI_RATELIMIT_REQUESTS_PER_SECOND=10
+
+    volumes:
+      # Podman socket (required)
+      - /run/podman/podman.sock:/run/podman/podman.sock
+
+      # Claude credentials (required)
+      - ~/.claude:/app/.claude:ro
+
+      # Session storage (persistent)
+      - stromboli-sessions:/app/sessions
+
+      # Workspaces (mount your projects)
+      - ~/projects:/workspace:ro
+
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+    restart: unless-stopped
+
+volumes:
+  stromboli-sessions:
+```
+
+## Production Configuration
+
+### With Authentication & TLS
+
+```yaml
+version: '3.8'
+
+services:
+  stromboli:
+    image: ghcr.io/tomblancdev/stromboli:latest
+    environment:
+      - STROMBOLI_PORT=8080
+      - STROMBOLI_AUTH_ENABLED=true
+      - STROMBOLI_AUTH_JWT_SECRET=${JWT_SECRET}
+      - STROMBOLI_AUTH_API_TOKEN=${API_TOKEN}
+      - STROMBOLI_RATELIMIT_ENABLED=true
+      - STROMBOLI_RATELIMIT_REQUESTS_PER_SECOND=5
+      - STROMBOLI_AGENT_ALLOWED_WORKSPACES=/workspace
+      - STROMBOLI_AGENT_DEFAULT_MEMORY=1g
+      - STROMBOLI_AGENT_DEFAULT_TIMEOUT=10m
+    volumes:
+      - /run/podman/podman.sock:/run/podman/podman.sock
+      - ~/.claude:/app/.claude:ro
+      - stromboli-sessions:/app/sessions
+      - /data/projects:/workspace:ro
+    restart: unless-stopped
+    networks:
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.stromboli.rule=Host(`stromboli.example.com`)"
+      - "traefik.http.routers.stromboli.tls=true"
+      - "traefik.http.routers.stromboli.tls.certresolver=letsencrypt"
+
+  traefik:
+    image: traefik:v2.10
+    command:
+      - "--providers.docker=true"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.email=you@example.com"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - traefik-certs:/letsencrypt
+    networks:
+      - traefik
+
+volumes:
+  stromboli-sessions:
+  traefik-certs:
+
+networks:
+  traefik:
+```
+
+## With Observability
+
+```yaml
+version: '3.8'
+
+services:
+  stromboli:
+    image: ghcr.io/tomblancdev/stromboli:latest
+    environment:
+      - STROMBOLI_TRACING_ENABLED=true
+      - STROMBOLI_TRACING_ENDPOINT=jaeger:4317
+      - STROMBOLI_TRACING_SERVICE_NAME=stromboli
+    # ... other config
+    depends_on:
+      - jaeger
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "16686:16686"  # UI
+      - "4317:4317"    # OTLP gRPC
+
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+```
+
+## Commands
+
+```bash
+# Start
+docker compose up -d
+
+# View logs
+docker compose logs -f stromboli
+
+# Stop
+docker compose down
+
+# Update
+docker compose pull
+docker compose up -d
+
+# Restart
+docker compose restart stromboli
+```
+
+## Environment File
+
+Create a `.env` file for secrets:
+
+```bash
+# .env
+JWT_SECRET=your-256-bit-secret
+API_TOKEN=your-api-token
+```
+
+Then reference in compose:
+```yaml
+services:
+  stromboli:
+    env_file:
+      - .env
+```
+
+!!! danger "Security"
+    Never commit `.env` files to git. Add to `.gitignore`.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1,0 +1,128 @@
+# Docker Deployment
+
+Run Stromboli in a Docker container.
+
+## Prerequisites
+
+- Docker or Podman installed
+- Claude CLI authenticated on the host
+- Podman socket accessible
+
+## Quick Start
+
+```bash
+docker run -d \
+  --name stromboli \
+  -p 8080:8080 \
+  -v /run/podman/podman.sock:/run/podman/podman.sock \
+  -v ~/.claude:/app/.claude:ro \
+  -v ./sessions:/app/sessions \
+  ghcr.io/tomblancdev/stromboli:latest
+```
+
+## Build from Source
+
+```bash
+git clone https://github.com/tomblancdev/stromboli
+cd stromboli
+
+# Build the image
+make build-server-image
+
+# Run
+docker run -d \
+  --name stromboli \
+  -p 8080:8080 \
+  -v /run/podman/podman.sock:/run/podman/podman.sock \
+  -v ~/.claude:/app/.claude:ro \
+  stromboli:latest
+```
+
+## Volume Mounts
+
+| Host Path | Container Path | Purpose |
+|-----------|----------------|---------|
+| `/run/podman/podman.sock` | `/run/podman/podman.sock` | Podman API socket |
+| `~/.claude` | `/app/.claude` | Claude credentials |
+| `./sessions` | `/app/sessions` | Session storage |
+
+## Environment Variables
+
+```bash
+docker run -d \
+  --name stromboli \
+  -p 8080:8080 \
+  -e STROMBOLI_AGENT_ALLOWED_WORKSPACES=/workspace \
+  -e STROMBOLI_AGENT_DEFAULT_MEMORY=512m \
+  -e STROMBOLI_AGENT_DEFAULT_TIMEOUT=5m \
+  -v /run/podman/podman.sock:/run/podman/podman.sock \
+  -v ~/.claude:/app/.claude:ro \
+  -v /home/user/projects:/workspace:ro \
+  stromboli:latest
+```
+
+## Health Check
+
+The container includes a health check:
+
+```bash
+docker inspect stromboli --format='{{.State.Health.Status}}'
+```
+
+## Logs
+
+```bash
+# Follow logs
+docker logs -f stromboli
+
+# Last 100 lines
+docker logs --tail 100 stromboli
+```
+
+## Updating
+
+```bash
+# Pull latest
+docker pull ghcr.io/tomblancdev/stromboli:latest
+
+# Restart
+docker stop stromboli
+docker rm stromboli
+docker run -d ... # same command as before
+```
+
+## Rootless Podman
+
+For rootless Podman, mount the user socket:
+
+```bash
+docker run -d \
+  --name stromboli \
+  -p 8080:8080 \
+  -v /run/user/1000/podman/podman.sock:/run/podman/podman.sock \
+  -v ~/.claude:/app/.claude:ro \
+  stromboli:latest
+```
+
+## Troubleshooting
+
+### "Cannot connect to Podman"
+
+Check the socket is mounted and accessible:
+```bash
+docker exec stromboli ls -la /run/podman/podman.sock
+```
+
+### "Claude not configured"
+
+Ensure credentials are mounted:
+```bash
+docker exec stromboli ls -la /app/.claude/
+```
+
+### Permission Issues
+
+The container runs as non-root (UID 1000). Ensure mounted directories have correct permissions:
+```bash
+chmod 755 ./sessions
+```

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -1,0 +1,237 @@
+# Production Deployment
+
+Best practices for running Stromboli in production.
+
+## Security Checklist
+
+- [ ] Enable authentication
+- [ ] Use HTTPS/TLS
+- [ ] Enable rate limiting
+- [ ] Configure workspace allowlist
+- [ ] Set resource limits
+- [ ] Use secrets management
+- [ ] Enable logging/monitoring
+- [ ] Regular security updates
+
+## Authentication
+
+Always enable authentication in production:
+
+```bash
+export STROMBOLI_AUTH_ENABLED=true
+export STROMBOLI_AUTH_JWT_SECRET="$(openssl rand -base64 32)"
+export STROMBOLI_AUTH_API_TOKEN="$(openssl rand -base64 32)"
+```
+
+## TLS/HTTPS
+
+Use a reverse proxy with TLS:
+
+=== "Traefik"
+
+    ```yaml
+    labels:
+      - "traefik.http.routers.stromboli.tls=true"
+      - "traefik.http.routers.stromboli.tls.certresolver=letsencrypt"
+    ```
+
+=== "Nginx"
+
+    ```nginx
+    server {
+        listen 443 ssl;
+        server_name stromboli.example.com;
+
+        ssl_certificate /etc/ssl/certs/stromboli.crt;
+        ssl_certificate_key /etc/ssl/private/stromboli.key;
+
+        location / {
+            proxy_pass http://localhost:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+    ```
+
+=== "Caddy"
+
+    ```
+    stromboli.example.com {
+        reverse_proxy localhost:8080
+    }
+    ```
+
+## Rate Limiting
+
+Protect against abuse:
+
+```bash
+export STROMBOLI_RATELIMIT_ENABLED=true
+export STROMBOLI_RATELIMIT_REQUESTS_PER_SECOND=5
+export STROMBOLI_RATELIMIT_BURST=10
+```
+
+## Resource Limits
+
+Set default limits to prevent runaway containers:
+
+```bash
+export STROMBOLI_AGENT_DEFAULT_MEMORY=1g
+export STROMBOLI_AGENT_DEFAULT_CPUS=2
+export STROMBOLI_AGENT_DEFAULT_TIMEOUT=10m
+```
+
+## Workspace Security
+
+Restrict accessible directories:
+
+```bash
+# Only allow specific paths
+export STROMBOLI_AGENT_ALLOWED_WORKSPACES="/data/projects,/data/workspaces"
+```
+
+Never allow:
+- `/` (root)
+- `/etc`, `/var`, `/usr`
+- Home directories with SSH keys
+- Directories with credentials
+
+## Monitoring
+
+### Prometheus Metrics
+
+Stromboli exposes metrics at `/metrics`:
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: 'stromboli'
+    static_configs:
+      - targets: ['stromboli:8080']
+```
+
+Key metrics:
+- `stromboli_active_containers` - Running containers
+- `stromboli_requests_total` - Total requests
+- `stromboli_request_duration_seconds` - Request latency
+
+### Logging
+
+Stromboli uses structured JSON logging. Forward to your log aggregator:
+
+```yaml
+services:
+  stromboli:
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+```
+
+### Tracing
+
+Enable OpenTelemetry tracing:
+
+```bash
+export STROMBOLI_TRACING_ENABLED=true
+export STROMBOLI_TRACING_ENDPOINT=jaeger:4317
+```
+
+## High Availability
+
+For HA deployments:
+
+1. **Stateless API**: Stromboli is stateless, scale horizontally
+2. **Shared Storage**: Use NFS or distributed storage for sessions
+3. **Load Balancer**: Use HAProxy, Nginx, or cloud LB
+
+```yaml
+services:
+  stromboli-1:
+    image: stromboli:latest
+    volumes:
+      - nfs-sessions:/app/sessions
+
+  stromboli-2:
+    image: stromboli:latest
+    volumes:
+      - nfs-sessions:/app/sessions
+
+  haproxy:
+    image: haproxy:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
+```
+
+## Backup
+
+### Session Data
+
+Regular backups of session storage:
+
+```bash
+# Backup
+tar -czf sessions-backup-$(date +%Y%m%d).tar.gz ./sessions
+
+# Restore
+tar -xzf sessions-backup-20240101.tar.gz
+```
+
+### Podman Secrets
+
+Export secrets for backup:
+
+```bash
+podman secret ls --format "{{.Name}}" | while read name; do
+  podman secret inspect $name > secrets/$name.json
+done
+```
+
+## Updates
+
+### Rolling Updates
+
+```bash
+# Pull new image
+docker compose pull
+
+# Update with zero downtime
+docker compose up -d --no-deps stromboli
+```
+
+### Version Pinning
+
+Pin to specific versions in production:
+
+```yaml
+services:
+  stromboli:
+    image: ghcr.io/tomblancdev/stromboli:v0.1.5-alpha
+```
+
+## Troubleshooting
+
+### Health Check Failed
+
+```bash
+# Check container logs
+docker compose logs stromboli
+
+# Check health endpoint
+curl http://localhost:8080/health
+```
+
+### High Memory Usage
+
+1. Check for orphaned containers: `podman ps -a`
+2. Reduce default memory limit
+3. Implement session cleanup
+
+### Slow Response Times
+
+1. Check Podman performance: `podman info`
+2. Check disk I/O for session storage
+3. Enable tracing to identify bottlenecks

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,0 +1,232 @@
+# Architecture
+
+Overview of Stromboli's internal architecture.
+
+## High-Level Architecture
+
+```mermaid
+graph TB
+    subgraph Client
+        A[HTTP Client]
+    end
+
+    subgraph Stromboli
+        B[Gin Router]
+        C[API Handlers]
+        D[Runner]
+        E[Session Manager]
+        F[Secrets Manager]
+        G[Job Manager]
+    end
+
+    subgraph Podman
+        H[Podman Socket]
+        I[Agent Container]
+        J[Claude CLI]
+    end
+
+    subgraph Storage
+        K[Sessions Dir]
+        L[Podman Secrets]
+    end
+
+    A -->|HTTP| B
+    B --> C
+    C --> D
+    C --> G
+    D --> E
+    D --> F
+    D -->|exec| H
+    H --> I
+    I --> J
+    E --> K
+    F --> L
+```
+
+## Package Structure
+
+```
+stromboli/
+├── cmd/stromboli/           # Entry point
+│   └── main.go              # Minimal - just wiring
+│
+├── internal/                # Private packages
+│   ├── api/                 # HTTP layer
+│   │   ├── server.go        # Router setup
+│   │   ├── run.go           # Request/response types
+│   │   ├── async.go         # Async job handlers
+│   │   ├── health.go        # Health checks
+│   │   ├── auth.go          # JWT authentication
+│   │   └── middleware.go    # Rate limiting, logging
+│   │
+│   ├── runner/              # Container execution
+│   │   ├── runner.go        # PodmanRunner
+│   │   ├── executor.go      # Command execution interface
+│   │   ├── image.go         # Image validation
+│   │   └── validation.go    # Input validation
+│   │
+│   ├── podman/              # Podman command building
+│   │   └── builder.go       # Fluent command builder
+│   │
+│   ├── claude/              # Claude CLI integration
+│   │   └── builder.go       # CLI argument builder
+│   │
+│   ├── secrets/             # Credentials management
+│   │   └── secrets.go       # Podman secrets sync
+│   │
+│   ├── session/             # Session storage
+│   │   └── manager.go       # Create/destroy sessions
+│   │
+│   ├── job/                 # Async job management
+│   │   └── manager.go       # Job lifecycle
+│   │
+│   ├── workspace/           # Workspace validation
+│   │   └── validator.go     # Path allowlist
+│   │
+│   ├── auth/                # Authentication
+│   │   ├── jwt.go           # Token generation
+│   │   └── middleware.go    # Auth middleware
+│   │
+│   ├── config/              # Configuration
+│   │   └── config.go        # Viper config loading
+│   │
+│   └── types/               # Shared types
+│       └── options.go       # ClaudeOptions, PodmanOptions
+│
+├── docs/                    # Documentation (MkDocs)
+├── deployments/             # Docker/Compose files
+└── api/                     # OpenAPI specs
+```
+
+## Request Flow
+
+### Synchronous Execution
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as API Handler
+    participant R as Runner
+    participant P as Podman
+    participant S as Storage
+
+    C->>A: POST /run
+    A->>A: Validate request
+    A->>R: Run(ctx, request)
+    R->>R: Sync credentials
+    R->>R: Validate workspace
+    R->>R: Build Podman command
+    R->>P: podman run ...
+    P->>P: Execute Claude
+    P->>S: Write session data
+    P-->>R: Output
+    R-->>A: Result
+    A-->>C: JSON response
+```
+
+### Async Execution
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as API Handler
+    participant J as Job Manager
+    participant R as Runner
+
+    C->>A: POST /run/async
+    A->>J: CreateJob()
+    J-->>A: job_id
+    A-->>C: {job_id, status: pending}
+
+    J->>R: Run(ctx, request)
+    Note over R: Execution happens async
+
+    C->>A: GET /jobs/{id}
+    A->>J: GetJob(id)
+    J-->>A: Job status
+    A-->>C: {status: running/completed}
+```
+
+## Key Interfaces
+
+### Runner
+
+```go
+type Runner interface {
+    Run(ctx context.Context, req Request) (*Result, error)
+    RunStream(ctx context.Context, req Request, output chan<- string) (*Result, error)
+    RunAsync(ctx context.Context, req Request, jobID string, onComplete func(*Result, error))
+    DestroySession(sessionID string) error
+    ListSessions() ([]string, error)
+}
+```
+
+### Executor
+
+```go
+type Executor interface {
+    Run(ctx context.Context, args []string) ([]byte, error)
+    RunStream(ctx context.Context, args []string) (stdout, stderr io.ReadCloser, start func() error, wait func() error, err error)
+}
+```
+
+## Security Model
+
+### Container Isolation
+
+Each agent runs in an isolated Podman container with:
+- Separate network namespace
+- Resource limits (CPU, memory)
+- Read-only root filesystem
+- Non-root user
+- No privileged capabilities
+
+### Credentials
+
+```
+Host                          Container
+~/.claude/.credentials.json → Podman Secret → /home/user/.claude/.credentials.json
+```
+
+Credentials never pass through the API - they're injected via Podman secrets.
+
+### Workspace Security
+
+```
+API Request          Validation           Container
+workspace=/foo → Allowlist check → Mount at /workspace
+```
+
+Only directories in the allowlist can be mounted.
+
+## Configuration Flow
+
+```mermaid
+graph LR
+    A[Environment Variables] --> D[Viper]
+    B[Config File] --> D
+    C[Defaults] --> D
+    D --> E[Config Struct]
+    E --> F[Server]
+    E --> G[Runner]
+```
+
+## Error Handling
+
+Errors are wrapped with context at each layer:
+
+```go
+// runner/runner.go
+return nil, fmt.Errorf("failed to create container: %w", err)
+
+// api/server.go
+return nil, fmt.Errorf("execution failed: %w", err)
+```
+
+API returns structured errors:
+```json
+{
+  "error": "execution failed: failed to create container: image not found",
+  "status": "error"
+}
+```

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,0 +1,230 @@
+# Contributing
+
+Thank you for considering contributing to Stromboli!
+
+## Development Setup
+
+### Prerequisites
+
+- Go 1.22+
+- Podman 4.0+
+- Make
+- Docker (for running tests in containers)
+
+### Clone & Build
+
+```bash
+git clone https://github.com/tomblancdev/stromboli
+cd stromboli
+make build
+```
+
+### Run Tests
+
+```bash
+# All tests
+make test
+
+# Unit tests only
+make test-unit
+
+# With coverage
+make test-coverage
+```
+
+### Run Locally
+
+```bash
+# Start Stromboli
+make run
+
+# Or with hot reload
+make dev
+```
+
+## Code Style
+
+### Go Guidelines
+
+- Follow [Effective Go](https://golang.org/doc/effective_go)
+- Use `gofmt` for formatting
+- Run `make lint` before committing
+
+### Package Structure
+
+```
+stromboli/
+├── cmd/stromboli/       # Entry point only
+├── internal/            # Private code
+│   ├── api/            # HTTP handlers
+│   ├── runner/         # Container execution
+│   ├── secrets/        # Credentials management
+│   └── ...
+├── pkg/                # Public libraries (if any)
+└── docs/               # Documentation
+```
+
+### Naming Conventions
+
+- **Packages**: lowercase, short (`runner`, not `runner_manager`)
+- **Files**: lowercase with underscores (`agent_test.go`)
+- **Exported**: PascalCase (`SpawnAgent`)
+- **Unexported**: camelCase (`createContainer`)
+
+## Making Changes
+
+### 1. Create a Branch
+
+```bash
+git checkout -b feat/my-feature
+# or
+git checkout -b fix/my-bugfix
+```
+
+### 2. Write Tests First (TDD)
+
+```bash
+# Write failing test
+make test  # Should fail
+
+# Implement feature
+make test  # Should pass
+```
+
+### 3. Commit with Conventional Commits
+
+```bash
+git commit -m "feat: add new feature"
+git commit -m "fix: resolve bug in X"
+git commit -m "docs: update API documentation"
+git commit -m "test: add tests for Y"
+git commit -m "refactor: simplify Z"
+```
+
+### 4. Create Pull Request
+
+```bash
+git push origin feat/my-feature
+gh pr create
+```
+
+## Pull Request Guidelines
+
+### Checklist
+
+- [ ] Tests pass (`make test`)
+- [ ] Linter passes (`make lint`)
+- [ ] New code has tests
+- [ ] Documentation updated if needed
+- [ ] Commit messages follow conventions
+
+### PR Template
+
+```markdown
+## Summary
+Brief description of changes.
+
+## Changes
+- Added X
+- Fixed Y
+- Updated Z
+
+## Test Plan
+- [ ] Unit tests pass
+- [ ] Manual testing done
+
+## Related Issues
+Closes #123
+```
+
+## Testing
+
+### Unit Tests
+
+Place tests next to the code:
+```
+internal/runner/runner.go
+internal/runner/runner_test.go
+```
+
+### Integration Tests
+
+```go
+// internal/runner/integration_test.go
+//go:build integration
+
+func TestRunnerIntegration(t *testing.T) {
+    // ...
+}
+```
+
+Run with:
+```bash
+go test -tags=integration ./...
+```
+
+### Test Helpers
+
+Use the mock executor for testing:
+
+```go
+func TestMyFeature(t *testing.T) {
+    mockExecutor := runner.NewMockExecutor()
+    mockExecutor.RunFunc = func(ctx context.Context, args []string) ([]byte, error) {
+        return []byte("ok"), nil
+    }
+    // ...
+}
+```
+
+## Documentation
+
+### Code Comments
+
+```go
+// Good: Explains why
+// RetryWithBackoff handles transient network failures common with Podman socket
+
+// Bad: Explains what (obvious from code)
+// This function retries the operation
+```
+
+### API Documentation
+
+Update Swagger annotations when changing API:
+
+```go
+// @Summary Run Claude
+// @Description Executes Claude in an isolated container
+// @Tags execution
+// @Accept json
+// @Produce json
+// @Param request body RunRequest true "Run request"
+// @Success 200 {object} RunResponse
+// @Router /run [post]
+func (s *Server) runClaude(c *gin.Context) {
+```
+
+## Release Process
+
+Releases are automated via GitHub Actions when a tag is pushed:
+
+```bash
+git tag v0.1.6-alpha
+git push origin v0.1.6-alpha
+```
+
+This triggers:
+1. Build binaries for all platforms
+2. Build and push Docker images
+3. Create GitHub release
+4. Update documentation
+
+## Getting Help
+
+- [GitHub Issues](https://github.com/tomblancdev/stromboli/issues) - Bug reports
+- [GitHub Discussions](https://github.com/tomblancdev/stromboli/discussions) - Questions
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,0 +1,271 @@
+# Testing
+
+Guide to testing Stromboli.
+
+## Running Tests
+
+```bash
+# All tests
+make test
+
+# Specific package
+go test ./internal/runner/...
+
+# With verbose output
+go test -v ./...
+
+# With coverage
+make test-coverage
+```
+
+## Test Structure
+
+### Unit Tests
+
+Located next to the code:
+```
+internal/runner/runner.go
+internal/runner/runner_test.go
+```
+
+### Test Naming
+
+```go
+func TestFunctionName_Scenario(t *testing.T) {
+    // ...
+}
+
+func TestFunctionName_Scenario_SubScenario(t *testing.T) {
+    // ...
+}
+```
+
+Examples:
+```go
+func TestValidateSecretsEnv_ValidCases(t *testing.T) { }
+func TestValidateSecretsEnv_InvalidEnvVarNames(t *testing.T) { }
+func TestListSecrets_PodmanError(t *testing.T) { }
+```
+
+## Mock Executor
+
+Use `MockExecutor` to test without Podman:
+
+```go
+func TestRunClaude(t *testing.T) {
+    mockExecutor := runner.NewMockExecutor()
+
+    // Configure mock responses
+    mockExecutor.RunFunc = func(ctx context.Context, args []string) ([]byte, error) {
+        if args[1] == "run" {
+            return []byte("Claude output"), nil
+        }
+        return nil, errors.New("unknown command")
+    }
+
+    // Create runner with mock
+    runner, err := runner.NewPodmanRunnerWithExecutor(
+        "image",
+        "/path/to/secrets",
+        "/path/to/sessions",
+        []string{"/allowed"},
+        mockExecutor,
+    )
+    require.NoError(t, err)
+
+    // Test
+    result, err := runner.Run(ctx, request)
+    assert.NoError(t, err)
+    assert.Equal(t, "Claude output", result.Output)
+}
+```
+
+## Table-Driven Tests
+
+Use table-driven tests for comprehensive coverage:
+
+```go
+func TestValidateSecretsEnv(t *testing.T) {
+    tests := []struct {
+        name       string
+        secretsEnv map[string]string
+        wantErr    bool
+        errContain string
+    }{
+        {
+            name:       "valid single secret",
+            secretsEnv: map[string]string{"GH_TOKEN": "github-token"},
+            wantErr:    false,
+        },
+        {
+            name:       "invalid env var name",
+            secretsEnv: map[string]string{"GH-TOKEN": "secret"},
+            wantErr:    true,
+            errContain: "invalid environment variable name",
+        },
+        {
+            name:       "dangerous env var",
+            secretsEnv: map[string]string{"LD_PRELOAD": "malicious"},
+            wantErr:    true,
+            errContain: "not allowed",
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            err := ValidateSecretsEnv(tt.secretsEnv)
+            if tt.wantErr {
+                assert.Error(t, err)
+                assert.Contains(t, err.Error(), tt.errContain)
+            } else {
+                assert.NoError(t, err)
+            }
+        })
+    }
+}
+```
+
+## HTTP Handler Tests
+
+Use `httptest` for API tests:
+
+```go
+func TestHealthCheck(t *testing.T) {
+    server := newTestServer(t, nil, false)
+
+    req, err := http.NewRequest(http.MethodGet, "/health", nil)
+    require.NoError(t, err)
+
+    rec := httptest.NewRecorder()
+    server.router.ServeHTTP(rec, req)
+
+    assert.Equal(t, http.StatusOK, rec.Code)
+
+    var response map[string]string
+    err = json.Unmarshal(rec.Body.Bytes(), &response)
+    require.NoError(t, err)
+
+    assert.Equal(t, "ok", response["status"])
+}
+```
+
+## Test Helpers
+
+### Temporary Directories
+
+```go
+func TestWithTempDir(t *testing.T) {
+    tmpDir := t.TempDir()  // Cleaned up automatically
+
+    credFile := filepath.Join(tmpDir, ".credentials.json")
+    require.NoError(t, os.WriteFile(credFile, []byte("{}"), 0600))
+
+    // Use credFile...
+}
+```
+
+### Test Fixtures
+
+```go
+func loadTestFixture(t *testing.T, name string) []byte {
+    t.Helper()
+    data, err := os.ReadFile(filepath.Join("testdata", name))
+    require.NoError(t, err)
+    return data
+}
+```
+
+## Integration Tests
+
+Build tag for integration tests:
+
+```go
+//go:build integration
+
+package runner
+
+import "testing"
+
+func TestRunnerIntegration(t *testing.T) {
+    if os.Getenv("PODMAN_AVAILABLE") != "true" {
+        t.Skip("Podman not available")
+    }
+    // Real Podman tests...
+}
+```
+
+Run:
+```bash
+PODMAN_AVAILABLE=true go test -tags=integration ./...
+```
+
+## Coverage
+
+### Generate Coverage Report
+
+```bash
+go test -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out -o coverage.html
+```
+
+### View Coverage
+
+```bash
+go tool cover -func=coverage.out
+```
+
+Output:
+```
+stromboli/internal/runner/runner.go:132:    Run             85.0%
+stromboli/internal/runner/validation.go:24: ValidateSecretsEnv  100.0%
+total:                                      (statements)    82.3%
+```
+
+### Coverage Targets
+
+| Package | Target |
+|---------|--------|
+| `internal/api` | 80% |
+| `internal/runner` | 85% |
+| `internal/secrets` | 90% |
+| `internal/auth` | 90% |
+
+## Continuous Integration
+
+Tests run automatically on PR:
+
+```yaml
+# .github/workflows/test.yml
+name: Test
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - run: make test
+      - run: make lint
+```
+
+## Debugging Tests
+
+### Verbose Output
+
+```bash
+go test -v ./internal/runner/... 2>&1 | tee test.log
+```
+
+### Run Single Test
+
+```bash
+go test -v -run TestValidateSecretsEnv_DangerousEnvVars ./internal/runner/...
+```
+
+### Debug with Delve
+
+```bash
+dlv test ./internal/runner/ -- -test.run TestMyFunction
+```

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,140 @@
+# Configuration
+
+Stromboli is configured via environment variables or a config file.
+
+## Environment Variables
+
+### Server Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STROMBOLI_PORT` | `8080` | HTTP server port |
+| `STROMBOLI_HOST` | `0.0.0.0` | Bind address |
+
+### Agent Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STROMBOLI_AGENT_IMAGE` | `stromboli-agent:latest` | Default container image |
+| `STROMBOLI_AGENT_SECRETS_FILE` | `~/.claude/.credentials.json` | Claude credentials path |
+| `STROMBOLI_AGENT_SESSIONS_DIR` | `./sessions` | Session storage directory |
+| `STROMBOLI_AGENT_ALLOWED_WORKSPACES` | (none) | Comma-separated allowed paths |
+
+### Resource Limits
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STROMBOLI_AGENT_DEFAULT_MEMORY` | (none) | Default memory limit (e.g., `512m`) |
+| `STROMBOLI_AGENT_DEFAULT_CPUS` | (none) | Default CPU limit (e.g., `1.0`) |
+| `STROMBOLI_AGENT_DEFAULT_TIMEOUT` | (none) | Default timeout (e.g., `5m`) |
+
+### Dynamic Images
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STROMBOLI_AGENT_ALLOWED_IMAGE_PATTERNS` | (none) | Allowed image patterns (e.g., `python:*,golang:*`) |
+| `STROMBOLI_AGENT_MOUNT_CLAUDE_CLI` | `false` | Mount Claude CLI into custom images |
+
+### Authentication
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STROMBOLI_AUTH_ENABLED` | `false` | Enable JWT authentication |
+| `STROMBOLI_AUTH_JWT_SECRET` | (none) | JWT signing secret |
+| `STROMBOLI_AUTH_API_TOKEN` | (none) | API token for token generation |
+
+### Rate Limiting
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STROMBOLI_RATELIMIT_ENABLED` | `false` | Enable rate limiting |
+| `STROMBOLI_RATELIMIT_REQUESTS_PER_SECOND` | `10` | Requests per second |
+| `STROMBOLI_RATELIMIT_BURST` | `20` | Burst allowance |
+
+### Observability
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STROMBOLI_TRACING_ENABLED` | `false` | Enable OpenTelemetry tracing |
+| `STROMBOLI_TRACING_ENDPOINT` | `localhost:4317` | OTLP endpoint |
+| `STROMBOLI_TRACING_SERVICE_NAME` | `stromboli` | Service name for traces |
+
+## Example Configurations
+
+### Development
+
+```bash
+export STROMBOLI_PORT=8080
+export STROMBOLI_AGENT_ALLOWED_WORKSPACES="/home/user/projects"
+```
+
+### Production
+
+```bash
+export STROMBOLI_PORT=8080
+export STROMBOLI_AUTH_ENABLED=true
+export STROMBOLI_AUTH_JWT_SECRET="your-secure-secret"
+export STROMBOLI_AUTH_API_TOKEN="your-api-token"
+export STROMBOLI_RATELIMIT_ENABLED=true
+export STROMBOLI_RATELIMIT_REQUESTS_PER_SECOND=5
+export STROMBOLI_AGENT_DEFAULT_MEMORY="1g"
+export STROMBOLI_AGENT_DEFAULT_TIMEOUT="10m"
+export STROMBOLI_AGENT_ALLOWED_WORKSPACES="/data/projects"
+```
+
+### Docker Compose
+
+```yaml
+services:
+  stromboli:
+    image: stromboli:latest
+    environment:
+      - STROMBOLI_PORT=8080
+      - STROMBOLI_AGENT_ALLOWED_WORKSPACES=/workspace
+      - STROMBOLI_AGENT_DEFAULT_MEMORY=512m
+      - STROMBOLI_AGENT_DEFAULT_TIMEOUT=5m
+    volumes:
+      - /run/podman/podman.sock:/run/podman/podman.sock
+      - ~/.claude:/app/.claude:ro
+      - ./sessions:/app/sessions
+    ports:
+      - "8080:8080"
+```
+
+## Config File
+
+You can also use a YAML config file:
+
+```yaml
+# stromboli.yaml
+server:
+  port: 8080
+  host: 0.0.0.0
+
+agent:
+  image: stromboli-agent:latest
+  secrets_file: ~/.claude/.credentials.json
+  sessions_dir: ./sessions
+  allowed_workspaces:
+    - /home/user/projects
+    - /data/workspaces
+  defaults:
+    memory: 512m
+    cpus: "1.0"
+    timeout: 5m
+
+auth:
+  enabled: true
+  jwt_secret: ${JWT_SECRET}
+  api_token: ${API_TOKEN}
+
+ratelimit:
+  enabled: true
+  requests_per_second: 10
+  burst: 20
+```
+
+Load with:
+```bash
+stromboli --config stromboli.yaml
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,97 @@
+# Installation
+
+## Requirements
+
+| Component | Version | Notes |
+|-----------|---------|-------|
+| Podman | 4.0+ | Container runtime |
+| Claude CLI | Latest | Authenticated with `claude` |
+| Go | 1.22+ | Only for building from source |
+
+## Installation Methods
+
+### Docker Compose (Recommended)
+
+The easiest way to run Stromboli:
+
+```bash
+git clone https://github.com/tomblancdev/stromboli
+cd stromboli
+docker compose up -d
+```
+
+This starts:
+
+- Stromboli API on port 8080
+- Automatic credential sync
+- Persistent session storage
+
+### Pre-built Binary
+
+Download from [GitHub Releases](https://github.com/tomblancdev/stromboli/releases):
+
+```bash
+# Linux amd64
+curl -LO https://github.com/tomblancdev/stromboli/releases/latest/download/stromboli-linux-amd64
+chmod +x stromboli-linux-amd64
+./stromboli-linux-amd64
+```
+
+### From Source
+
+```bash
+git clone https://github.com/tomblancdev/stromboli
+cd stromboli
+
+# Build
+make build
+
+# Or with Go directly
+go build -o stromboli ./cmd/stromboli
+```
+
+### Docker Image
+
+```bash
+# Pull the image
+docker pull ghcr.io/tomblancdev/stromboli:latest
+
+# Run with Podman socket
+docker run -d \
+  -p 8080:8080 \
+  -v /run/podman/podman.sock:/run/podman/podman.sock \
+  -v ~/.claude:/app/.claude:ro \
+  ghcr.io/tomblancdev/stromboli:latest
+```
+
+## Verify Installation
+
+```bash
+# Check health
+curl http://localhost:8080/health
+
+# Check Claude status
+curl http://localhost:8080/claude/status
+```
+
+## Claude CLI Setup
+
+Stromboli requires an authenticated Claude CLI:
+
+```bash
+# Install Claude CLI
+npm install -g @anthropic-ai/claude-code
+
+# Authenticate
+claude
+
+# Verify
+claude --version
+```
+
+The credentials are stored in `~/.claude/.credentials.json`.
+
+## Next Steps
+
+- [Configuration](configuration.md) - Customize Stromboli
+- [Quick Start](quickstart.md) - Run your first agent

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,135 @@
+# Quick Start
+
+Get Stromboli running in 5 minutes.
+
+## Prerequisites
+
+- [Podman](https://podman.io/) v4.0+ installed
+- Claude CLI authenticated (`claude` command works)
+- Docker Compose (optional, for easy deployment)
+
+## Step 1: Clone & Start
+
+=== "Docker Compose"
+
+    ```bash
+    git clone https://github.com/tomblancdev/stromboli
+    cd stromboli
+
+    # Start Stromboli
+    docker compose up -d
+
+    # Check health
+    curl http://localhost:8080/health
+    ```
+
+=== "From Source"
+
+    ```bash
+    git clone https://github.com/tomblancdev/stromboli
+    cd stromboli
+
+    # Build
+    make build
+
+    # Run
+    ./stromboli --port 8080
+    ```
+
+## Step 2: Verify Installation
+
+```bash
+curl -s http://localhost:8080/health | jq
+```
+
+Expected output:
+```json
+{
+  "status": "ok",
+  "name": "stromboli",
+  "version": "0.1.5-alpha",
+  "components": [
+    {"name": "podman", "status": "ok"},
+    {"name": "claude-credentials-file", "status": "ok"},
+    {"name": "claude-credentials-secret", "status": "ok"}
+  ]
+}
+```
+
+## Step 3: Run Your First Agent
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "What is 2 + 2? Reply with just the number."
+  }'
+```
+
+Response:
+```json
+{
+  "id": "run-abc123def456",
+  "status": "completed",
+  "output": "4",
+  "session_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+## Step 4: Run with a Workspace
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "List the files in this directory",
+    "workspace": "/home/user/myproject"
+  }'
+```
+
+!!! warning "Workspace Allowlist"
+    By default, workspaces must be in the allowlist. Configure `STROMBOLI_AGENT_ALLOWED_WORKSPACES` to allow your directories.
+
+## Step 5: Continue a Conversation
+
+Use the `session_id` from the previous response:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Now explain what each file does",
+    "workspace": "/home/user/myproject",
+    "claude": {
+      "session_id": "550e8400-e29b-41d4-a716-446655440000",
+      "resume": true
+    }
+  }'
+```
+
+## Next Steps
+
+- [Configuration](configuration.md) - Customize settings
+- [Secrets Guide](../guide/secrets.md) - Inject GitHub/GitLab tokens
+- [API Reference](../api/overview.md) - Full API documentation
+
+## Troubleshooting
+
+### "Claude not configured"
+
+Run `claude` in your terminal to authenticate, then restart Stromboli.
+
+### "Workspace not allowed"
+
+Add your workspace to the allowlist:
+```bash
+export STROMBOLI_AGENT_ALLOWED_WORKSPACES="/home/user/projects,/var/data"
+```
+
+### Container fails to start
+
+Check Podman is running:
+```bash
+podman version
+podman ps
+```

--- a/docs/guide/running-agents.md
+++ b/docs/guide/running-agents.md
@@ -1,0 +1,181 @@
+# Running Agents
+
+Learn how to run Claude agents with Stromboli.
+
+## Basic Request
+
+The simplest way to run an agent:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Hello, Claude!"
+  }'
+```
+
+## With a Workspace
+
+Mount a directory for the agent to work with:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Analyze the code in this project",
+    "workspace": "/home/user/myproject"
+  }'
+```
+
+The workspace is mounted at `/workspace` inside the container.
+
+## Claude Options
+
+Configure Claude's behavior:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Review this code",
+    "workspace": "/home/user/myproject",
+    "claude": {
+      "model": "sonnet",
+      "system_prompt": "You are a senior Go developer",
+      "max_budget_usd": 1.00,
+      "allowed_tools": ["Read", "Grep", "Glob"],
+      "output_format": "json"
+    }
+  }'
+```
+
+### Available Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `model` | string | Model: `sonnet`, `opus`, `haiku` |
+| `system_prompt` | string | Replace default system prompt |
+| `append_system_prompt` | string | Append to system prompt |
+| `max_budget_usd` | float | Maximum API cost |
+| `allowed_tools` | []string | Whitelist tools |
+| `disallowed_tools` | []string | Blacklist tools |
+| `output_format` | string | `text`, `json`, `stream-json` |
+| `dangerously_skip_permissions` | bool | Skip permission prompts |
+
+## Container Options
+
+Configure the Podman container:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Run heavy analysis",
+    "workspace": "/home/user/myproject",
+    "podman": {
+      "memory": "2g",
+      "cpus": "2",
+      "timeout": "30m",
+      "image": "python:3.12"
+    }
+  }'
+```
+
+### Container Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `memory` | string | Memory limit (e.g., `512m`, `2g`) |
+| `cpus` | string | CPU limit (e.g., `0.5`, `2`) |
+| `timeout` | string | Max runtime (e.g., `5m`, `1h`) |
+| `image` | string | Custom container image |
+| `volumes` | []string | Additional volume mounts |
+| `secrets_env` | map | Secrets as env vars |
+
+## Async Execution
+
+Run agents asynchronously for long tasks:
+
+```bash
+# Start async job
+curl -X POST http://localhost:8080/run/async \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Refactor the entire codebase",
+    "workspace": "/home/user/myproject"
+  }'
+```
+
+Response:
+```json
+{
+  "job_id": "job-abc123",
+  "status": "pending"
+}
+```
+
+Check job status:
+```bash
+curl http://localhost:8080/jobs/job-abc123
+```
+
+## Streaming Output
+
+Get real-time output via Server-Sent Events:
+
+```bash
+curl -N "http://localhost:8080/run/stream?prompt=Hello&workspace=/home/user/project"
+```
+
+Output:
+```
+data: {"type":"output","content":"Hello! I'm analyzing..."}
+data: {"type":"output","content":"Found 3 files..."}
+data: {"type":"done","session_id":"..."}
+```
+
+## Webhooks
+
+Get notified when async jobs complete:
+
+```bash
+curl -X POST http://localhost:8080/run/async \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Long running task",
+    "webhook_url": "https://your-server.com/webhook"
+  }'
+```
+
+Webhook payload:
+```json
+{
+  "job_id": "job-abc123",
+  "status": "completed",
+  "output": "Task completed...",
+  "session_id": "..."
+}
+```
+
+## Custom Images
+
+Use different container images (must be in allowlist):
+
+```bash
+# Python environment
+curl -X POST http://localhost:8080/run \
+  -d '{
+    "prompt": "Run Python analysis",
+    "podman": {"image": "python:3.12"}
+  }'
+
+# Go environment
+curl -X POST http://localhost:8080/run \
+  -d '{
+    "prompt": "Build and test",
+    "podman": {"image": "golang:1.22"}
+  }'
+```
+
+!!! note "Image Allowlist"
+    Configure `STROMBOLI_AGENT_ALLOWED_IMAGE_PATTERNS` to allow custom images.

--- a/docs/guide/secrets.md
+++ b/docs/guide/secrets.md
@@ -1,0 +1,255 @@
+# Secrets Management
+
+Stromboli allows you to securely inject secrets into agent containers as environment variables. This enables agents to access external services like GitHub, GitLab, cloud providers, etc.
+
+> **⚠️ Security Model**: Stromboli is designed for **single-tenant deployments**. All API users have access to all Podman secrets on the host. For multi-tenant environments, deploy separate Stromboli instances per tenant.
+
+## How It Works
+
+```
+┌─────────────────────────────────────────────────────┐
+│              Host Machine                            │
+│  podman secret create github-token ~/.gh/token      │
+└─────────────────────┬───────────────────────────────┘
+                      │ stored securely
+                      ▼
+┌─────────────────────────────────────────────────────┐
+│              Podman Secrets Store                    │
+│  - claude-credentials (managed by stromboli)        │
+│  - github-token (user-created)                      │
+│  - gitlab-token (user-created)                      │
+└─────────────────────┬───────────────────────────────┘
+                      │ API request: secrets_env
+                      ▼
+┌─────────────────────────────────────────────────────┐
+│              Agent Container                         │
+│  GH_TOKEN=<secret value>                            │
+│  GITLAB_TOKEN=<secret value>                        │
+└─────────────────────────────────────────────────────┘
+```
+
+## Creating Secrets
+
+### GitHub CLI Token
+
+```bash
+# Option 1: Extract OAuth token from gh CLI config (requires yq)
+yq -r '.["github.com"].oauth_token' ~/.config/gh/hosts.yml | podman secret create github-token -
+
+# Option 2: Create from a Personal Access Token
+echo "ghp_xxxxxxxxxxxx" | podman secret create github-token -
+
+# Option 3: From environment variable
+echo "$GITHUB_TOKEN" | podman secret create github-token -
+
+# Option 4: Create interactively (token won't appear in shell history)
+podman secret create github-token -
+# Then paste the token and press Ctrl+D
+```
+
+### GitLab Token
+
+```bash
+echo "$GITLAB_TOKEN" | podman secret create gitlab-token -
+```
+
+### Generic API Keys
+
+```bash
+echo "sk-xxxxxxxxxxxx" | podman secret create openai-key -
+echo "xoxb-xxxxxxxxxxxx" | podman secret create slack-token -
+```
+
+## Using Secrets in API Requests
+
+### List Available Secrets
+
+```bash
+curl -s http://localhost:8080/secrets | jq
+```
+
+Response:
+```json
+{
+  "secrets": ["claude-credentials", "github-token", "gitlab-token"]
+}
+```
+
+### Inject Secrets into Agent
+
+Use the `secrets_env` field in your request to map Podman secrets to environment variables:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Review the open PRs on this repo using gh CLI",
+    "workspace": "/home/user/myproject",
+    "podman": {
+      "secrets_env": {
+        "GH_TOKEN": "github-token",
+        "GITLAB_TOKEN": "gitlab-token"
+      }
+    }
+  }'
+```
+
+The format is:
+```json
+{
+  "secrets_env": {
+    "<ENV_VAR_NAME>": "<podman_secret_name>"
+  }
+}
+```
+
+### Validation Rules
+
+Stromboli validates `secrets_env` before creating containers:
+
+| Rule | Description |
+|------|-------------|
+| **Env var format** | Must start with letter or underscore, contain only `[a-zA-Z0-9_]` |
+| **Blocked vars** | `LD_PRELOAD`, `LD_LIBRARY_PATH` are blocked for security |
+| **Secret name** | Cannot be empty, max 253 characters |
+| **Max secrets** | Maximum 50 secrets per request |
+
+Invalid requests return `400 Bad Request` with details:
+```json
+{
+  "error": "secrets validation failed: invalid environment variable name \"MY-VAR\": must start with letter or underscore, contain only alphanumeric and underscore"
+}
+```
+
+## Security Guidelines
+
+### DO
+
+- **Use Podman secrets** - Never pass tokens directly in API requests or environment variables
+- **Use minimal permissions** - Create tokens with only the permissions needed
+- **Rotate regularly** - Update secrets periodically
+- **Name secrets clearly** - Use descriptive names like `github-token`, `gitlab-readonly`
+- **List before using** - Check `/secrets` endpoint to see available secrets
+
+### DON'T
+
+- **Don't hardcode tokens** - Never put tokens in code, configs, or API requests
+- **Don't share secrets** - Each environment should have its own secrets
+- **Don't use overly permissive tokens** - Avoid admin/full-access tokens when read-only works
+- **Don't log secrets** - Stromboli never logs secret values
+
+### Token Permissions
+
+Create tokens with minimal required permissions:
+
+| Service | Use Case | Recommended Permissions |
+|---------|----------|------------------------|
+| GitHub | PR review | `repo:read`, `pull_request:read` |
+| GitHub | PR actions | `repo:write`, `pull_request:write` |
+| GitLab | Read repos | `read_repository` |
+| GitLab | CI/CD | `read_repository`, `read_api` |
+
+## Managing Secrets
+
+### List Secrets
+
+```bash
+podman secret ls
+```
+
+### Inspect Secret (metadata only)
+
+```bash
+podman secret inspect github-token
+```
+
+### Update a Secret
+
+```bash
+# Remove old secret
+podman secret rm github-token
+
+# Create new secret with updated value
+echo "new-token-value" | podman secret create github-token -
+```
+
+### Delete a Secret
+
+```bash
+podman secret rm github-token
+```
+
+## Troubleshooting
+
+### Secret Not Found
+
+```
+Error: secret "github-token" not found
+```
+
+**Solution**: Create the secret first:
+```bash
+echo "$TOKEN" | podman secret create github-token -
+```
+
+### Permission Denied
+
+If the agent can't use the secret, ensure:
+1. The secret exists: `podman secret ls`
+2. The secret name in the request matches exactly
+3. The Podman socket is accessible
+
+### Token Expired
+
+If operations fail with auth errors, the token may be expired:
+```bash
+# Update the secret
+podman secret rm github-token
+echo "$NEW_TOKEN" | podman secret create github-token -
+```
+
+## Examples
+
+### GitHub PR Review Agent
+
+```bash
+# Setup
+echo "$GITHUB_TOKEN" | podman secret create github-token -
+
+# Run
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "List open PRs and summarize the changes in PR #42",
+    "workspace": "/home/user/myrepo",
+    "podman": {
+      "secrets_env": {
+        "GH_TOKEN": "github-token"
+      }
+    }
+  }'
+```
+
+### Multi-Service Agent
+
+```bash
+# Setup multiple secrets
+echo "$GITHUB_TOKEN" | podman secret create github-token -
+echo "$SLACK_TOKEN" | podman secret create slack-token -
+echo "$OPENAI_KEY" | podman secret create openai-key -
+
+# Run with multiple secrets
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Analyze the latest PR, generate a summary, and post it to #dev-updates",
+    "workspace": "/home/user/myrepo",
+    "podman": {
+      "secrets_env": {
+        "GH_TOKEN": "github-token",
+        "SLACK_BOT_TOKEN": "slack-token",
+        "OPENAI_API_KEY": "openai-key"
+      }
+    }
+  }'
+```

--- a/docs/guide/sessions.md
+++ b/docs/guide/sessions.md
@@ -1,0 +1,180 @@
+# Sessions
+
+Sessions allow conversations to persist across multiple requests.
+
+## How Sessions Work
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Stromboli
+    participant Container
+    participant Storage
+
+    User->>Stromboli: POST /run (prompt)
+    Stromboli->>Container: Run Claude
+    Container->>Storage: Save session
+    Stromboli->>User: {session_id: "abc123"}
+
+    User->>Stromboli: POST /run (resume: true)
+    Stromboli->>Storage: Load session
+    Stromboli->>Container: Continue conversation
+    Container->>User: Response with context
+```
+
+## Creating a Session
+
+Every request creates a new session by default:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -d '{"prompt": "Hello, remember my name is Tom"}'
+```
+
+Response:
+```json
+{
+  "output": "Hello Tom! Nice to meet you...",
+  "session_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+## Resuming a Session
+
+Use the session ID to continue the conversation:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -d '{
+    "prompt": "What is my name?",
+    "claude": {
+      "session_id": "550e8400-e29b-41d4-a716-446655440000",
+      "resume": true
+    }
+  }'
+```
+
+Response:
+```json
+{
+  "output": "Your name is Tom!",
+  "session_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+## Session Options
+
+### Resume vs Continue
+
+| Option | Description |
+|--------|-------------|
+| `resume: true` | Continue specific session by ID |
+| `continue: true` | Continue most recent session in workspace |
+
+```bash
+# Resume specific session
+{"claude": {"session_id": "abc123", "resume": true}}
+
+# Continue most recent
+{"claude": {"continue": true}}
+```
+
+### Fork a Session
+
+Create a new session from an existing one:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -d '{
+    "prompt": "Try a different approach",
+    "claude": {
+      "session_id": "abc123",
+      "fork_session": true
+    }
+  }'
+```
+
+This creates a new session with the conversation history but a new ID.
+
+### No Persistence
+
+Run without saving the session:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -d '{
+    "prompt": "One-off question",
+    "claude": {
+      "no_persistence": true
+    }
+  }'
+```
+
+## Managing Sessions
+
+### List Sessions
+
+```bash
+curl http://localhost:8080/sessions
+```
+
+Response:
+```json
+{
+  "sessions": [
+    "550e8400-e29b-41d4-a716-446655440000",
+    "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+  ]
+}
+```
+
+### Get Session Messages
+
+```bash
+curl http://localhost:8080/sessions/550e8400.../messages
+```
+
+Response:
+```json
+{
+  "messages": [
+    {"role": "user", "content": "Hello"},
+    {"role": "assistant", "content": "Hi there!"}
+  ]
+}
+```
+
+### Delete a Session
+
+```bash
+curl -X DELETE http://localhost:8080/sessions/550e8400...
+```
+
+Response:
+```json
+{
+  "success": true,
+  "session_id": "550e8400..."
+}
+```
+
+## Session Storage
+
+Sessions are stored in the directory configured by `STROMBOLI_AGENT_SESSIONS_DIR` (default: `./sessions`).
+
+```
+sessions/
+├── 550e8400-e29b-41d4-a716-446655440000/
+│   ├── .claude/
+│   │   └── sessions/
+│   └── ...
+└── 6ba7b810-9dad-11d1-80b4-00c04fd430c8/
+    └── ...
+```
+
+!!! tip "Cleanup"
+    Periodically delete old sessions to free disk space:
+    ```bash
+    # Delete sessions older than 7 days
+    find ./sessions -type d -mtime +7 -exec rm -rf {} \;
+    ```

--- a/docs/guide/workspaces.md
+++ b/docs/guide/workspaces.md
@@ -1,0 +1,147 @@
+# Workspaces
+
+Workspaces allow Claude agents to access directories on the host system.
+
+## How Workspaces Work
+
+When you specify a workspace, Stromboli mounts it into the container:
+
+```
+Host: /home/user/myproject
+  ↓
+Container: /workspace
+```
+
+The agent can read and write files in this directory.
+
+## Using Workspaces
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "List all Go files in this project",
+    "workspace": "/home/user/myproject"
+  }'
+```
+
+## Security: Workspace Allowlist
+
+By default, Stromboli restricts which directories can be mounted.
+
+### Configure Allowed Workspaces
+
+```bash
+export STROMBOLI_AGENT_ALLOWED_WORKSPACES="/home/user/projects,/data/workspaces"
+```
+
+Or in config file:
+```yaml
+agent:
+  allowed_workspaces:
+    - /home/user/projects
+    - /data/workspaces
+```
+
+### Subdirectories
+
+Subdirectories of allowed paths are automatically permitted:
+
+```bash
+# If /home/user/projects is allowed:
+/home/user/projects           # ✅ Allowed
+/home/user/projects/foo       # ✅ Allowed
+/home/user/projects/foo/bar   # ✅ Allowed
+/home/user/other              # ❌ Denied
+```
+
+### Path Traversal Protection
+
+Stromboli blocks path traversal attempts:
+
+```bash
+# These are blocked:
+/home/user/projects/../secrets  # ❌ Blocked
+/home/user/projects/./../../    # ❌ Blocked
+```
+
+## Additional Volumes
+
+Mount extra directories with the `volumes` option:
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -d '{
+    "prompt": "Process the data",
+    "workspace": "/home/user/project",
+    "podman": {
+      "volumes": [
+        "/data/input:/input:ro",
+        "/data/output:/output"
+      ]
+    }
+  }'
+```
+
+Volume format: `host_path:container_path[:options]`
+
+Options:
+- `ro` - Read-only
+- `rw` - Read-write (default)
+
+## Best Practices
+
+### 1. Use Specific Paths
+
+```bash
+# Good: Specific project
+"workspace": "/home/user/projects/myapp"
+
+# Bad: Too broad
+"workspace": "/home/user"
+```
+
+### 2. Limit Permissions
+
+```bash
+# Mount data as read-only when possible
+"volumes": ["/data/config:/config:ro"]
+```
+
+### 3. Don't Mount Sensitive Directories
+
+Never allow these paths:
+- `/` (root)
+- `/etc`
+- `/home/user/.ssh`
+- `/home/user/.aws`
+
+### 4. Use Absolute Paths
+
+```bash
+# Good
+"workspace": "/home/user/projects/myapp"
+
+# Bad - relative paths may not work as expected
+"workspace": "./myapp"
+```
+
+## Troubleshooting
+
+### "Workspace not allowed"
+
+Add the path to your allowlist:
+```bash
+export STROMBOLI_AGENT_ALLOWED_WORKSPACES="/your/path"
+```
+
+### "Path traversal detected"
+
+Your path contains `..` - use an absolute path instead.
+
+### Files not visible to agent
+
+Check:
+1. The path exists on the host
+2. Stromboli has read permission
+3. The path is in the allowlist

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,107 @@
+# Stromboli
+
+<p align="center">
+  <strong>Container orchestration API for Claude Code agents</strong>
+</p>
+
+<p align="center">
+  <a href="getting-started/quickstart/">Get Started</a> •
+  <a href="api/overview/">API Reference</a> •
+  <a href="https://github.com/tomblancdev/stromboli">GitHub</a>
+</p>
+
+---
+
+## What is Stromboli?
+
+Stromboli is a **container orchestration API** that spawns and manages isolated [Claude Code](https://claude.ai/claude-code) agents in Podman containers. It's the Podman-based alternative to Pinocchio.
+
+```mermaid
+graph LR
+    A[API Request] --> B[Stromboli]
+    B --> C[Podman]
+    C --> D[Claude Agent Container]
+    D --> E[Your Workspace]
+```
+
+## Key Features
+
+<div class="grid cards" markdown>
+
+- :material-docker: **Container Isolation**
+
+    Each agent runs in its own isolated Podman container with resource limits.
+
+- :material-key: **Secrets Management**
+
+    Securely inject tokens (GitHub, GitLab, etc.) as environment variables.
+
+- :material-history: **Session Persistence**
+
+    Continue conversations across requests with session management.
+
+- :material-api: **REST API**
+
+    Simple HTTP API for spawning agents, managing jobs, and streaming output.
+
+- :material-shield-check: **Security First**
+
+    Input validation, workspace allowlists, and credential isolation.
+
+- :material-cog: **Configurable**
+
+    Resource limits, timeouts, custom images, and more.
+
+</div>
+
+## Quick Example
+
+```bash
+# Run a Claude agent
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Analyze this Go project and suggest improvements",
+    "workspace": "/home/user/myproject"
+  }'
+```
+
+Response:
+```json
+{
+  "id": "run-abc123",
+  "status": "completed",
+  "output": "I've analyzed the project...",
+  "session_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+## Installation
+
+=== "Docker Compose (Recommended)"
+
+    ```bash
+    git clone https://github.com/tomblancdev/stromboli
+    cd stromboli
+    docker compose up -d
+    ```
+
+=== "From Source"
+
+    ```bash
+    git clone https://github.com/tomblancdev/stromboli
+    cd stromboli
+    make build
+    ./stromboli
+    ```
+
+## Next Steps
+
+- [Quick Start Guide](getting-started/quickstart.md) - Get up and running in 5 minutes
+- [Configuration](getting-started/configuration.md) - Customize Stromboli for your needs
+- [API Reference](api/overview.md) - Complete API documentation
+- [Secrets Guide](guide/secrets.md) - Inject tokens securely
+
+## License
+
+Stromboli is open source under the MIT License.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,126 @@
+site_name: Stromboli
+site_description: Container orchestration API for Claude Code agents
+site_url: https://tomblancdev.github.io/stromboli
+repo_url: https://github.com/tomblancdev/stromboli
+repo_name: tomblancdev/stromboli
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  logo: assets/logo.svg
+  favicon: assets/logo.svg
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+  palette:
+    # Light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+  # mike plugin is installed in CI for versioning
+  # Uncomment for local testing with mike:
+  # - mike:
+  #     version_selector: true
+  #     css_dir: css
+  #     javascript_dir: js
+  #     canonical_version: latest
+
+extra:
+  version:
+    provider: mike
+    default: latest
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/tomblancdev/stromboli
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.magiclink:
+      repo_url_shorthand: true
+      user: tomblancdev
+      repo: stromboli
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Quick Start: getting-started/quickstart.md
+    - Installation: getting-started/installation.md
+    - Configuration: getting-started/configuration.md
+  - User Guide:
+    - Running Agents: guide/running-agents.md
+    - Sessions: guide/sessions.md
+    - Secrets: guide/secrets.md
+    - Workspaces: guide/workspaces.md
+  - API Reference:
+    - Overview: api/overview.md
+    - Endpoints: api/endpoints.md
+    - Authentication: api/authentication.md
+  - Deployment:
+    - Docker: deployment/docker.md
+    - Docker Compose: deployment/compose.md
+    - Production: deployment/production.md
+  - Development:
+    - Contributing: development/contributing.md
+    - Architecture: development/architecture.md
+    - Testing: development/testing.md
+  - Changelog: changelog.md


### PR DESCRIPTION
## Summary
- Add comprehensive MkDocs documentation site with Material theme
- Add GitHub Actions for versioned docs deployment (deploys on release tags)
- Add GitHub Actions for docs preview on PRs

## Documentation Structure
- 🚀 **Getting Started**: quickstart, installation, configuration
- 📖 **User Guide**: running agents, sessions, secrets, workspaces
- 📡 **API Reference**: overview, endpoints, authentication
- 🚢 **Deployment**: docker, compose, production best practices
- 🛠️ **Development**: contributing, architecture, testing
- 📝 **Changelog**: release history

## Features
- 🌋 Custom volcano logo (Stromboli theme)
- 🌙 Dark/light mode toggle
- 🔍 Full-text search
- 📱 Responsive design
- 🏷️ Version selector (via mike plugin)
- ✏️ Edit on GitHub links

## After Merge
1. Enable GitHub Pages: Settings → Pages → Source: "GitHub Actions"
2. Create a tag (e.g., `v0.1.6-alpha`) to trigger first deployment
3. Docs will be live at: https://tomblancdev.github.io/stromboli

## Test plan
- [x] MkDocs builds successfully locally
- [x] All pages render correctly
- [ ] GitHub Actions workflow runs on tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)