### PR TITLE
fix: Point Dependabot Docker ecosystem at correct directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,9 +37,22 @@ updates:
         patterns:
           - "*"
 
-  # Docker (Containerfile)
+  # Docker (deployment images)
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/deployments/docker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "docker"
+
+  # Docker (devcontainer)
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary
- The Docker ecosystem in `dependabot.yml` was configured to scan `/` (root), but all Dockerfiles are in `deployments/docker/` and `.devcontainer/`
- This caused the Dependabot Docker update job to **fail every week** silently
- Now correctly points at both directories so base image updates will be detected

## Test plan
- [ ] Verify Dependabot Docker job stops failing on next weekly run
- [ ] Check that PRs are created when base images have updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)