### PR TITLE
fix: Bump CI Go version and OTel semconv for dependency update

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version: '1.24'
 
       - name: Install swag
         run: go install github.com/swaggo/swag/cmd/swag@latest

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -14,7 +14,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"


### PR DESCRIPTION
## Summary
- Bumps Go version in `validate.yml` from 1.22 to 1.24 (required by go.mod after #13 merge)
- Updates OTel semconv import from v1.24.0 to v1.39.0 to match the bumped SDK version, fixing `resource.Merge` schema URL conflict

## Root Cause
PR #13 bumped Go deps including OTel SDK to v1.39.0, but:
1. CI still used Go 1.22 → `go.mod requires go >= 1.24.2` failure
2. Semconv import was still v1.24.0 → `conflicting Schema URL: v1.39.0 and v1.24.0`

## Test plan
- [x] `internal/tracing` tests pass locally (previously all failing)
- [ ] CI OpenAPI Specs job should pass with Go 1.24

🤖 Generated with [Claude Code](https://claude.com/claude-code)