### PR TITLE
fix: resolve issues #35-#40 (session path, zero-values, orphans, async tracking, structured output, crash logs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ curl -X POST http://localhost:8080/run \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "Create a new Go project structure",
-    "workspace": "/home/user/newproject"
+    "workdir": "/home/user/newproject"
   }'
 
 # Response includes: "session_id": "sess-abc123"
@@ -204,7 +204,7 @@ curl -X POST http://localhost:8080/run \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "Now add unit tests for the main package",
-    "workspace": "/home/user/newproject",
+    "workdir": "/home/user/newproject",
     "claude": {
       "session_id": "sess-abc123",
       "resume": true

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ curl -X POST http://localhost:8080/run \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "Analyze this Go code for bugs",
-    "workspace": "/home/user/myproject",
+    "workdir": "/home/user/myproject",
     "claude": {
       "model": "sonnet",
       "dangerously_skip_permissions": true
@@ -159,7 +159,7 @@ curl -X POST http://localhost:8080/run/async \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "Refactor this entire codebase for better maintainability",
-    "workspace": "/home/user/large-project",
+    "workdir": "/home/user/large-project",
     "webhook_url": "https://myapp.com/webhook",
     "claude": {
       "model": "opus",
@@ -167,7 +167,7 @@ curl -X POST http://localhost:8080/run/async \
     }
   }'
 
-# Response: {"job_id": "job-abc123def456"}
+# Response: {"job_id": "job-abc123def456", "session_id": "550e8400-..."}
 
 # Poll for status
 curl http://localhost:8080/jobs/job-abc123def456
@@ -327,6 +327,7 @@ Stromboli exposes all Claude CLI options. See [docs/API.md](docs/API.md) for com
     "permission_mode": "bypassPermissions",    // Permission mode
     "system_prompt": "You are a senior dev",   // Custom system prompt
     "max_budget_usd": 10.0,                    // Budget limit
+    "max_turns": 30,                           // Max agentic turns (0 = unlimited)
     "timeout": "30m"                           // Claude timeout
   }
 }
@@ -374,7 +375,7 @@ Key components:
 - **API Layer**: HTTP handlers, authentication, request validation
 - **Runner Layer**: Orchestration logic, execution modes (sync/async/stream)
 - **Command Builders**: Construct Podman and Claude CLI commands
-- **Job Manager**: Track async jobs, cleanup, webhook notifications
+- **Job Manager**: Track async jobs, cleanup, crash detection, webhook notifications
 - **Session Manager**: Persistent session state across calls
 - **Secrets Manager**: Secure Claude token handling via Podman secrets
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -84,7 +84,7 @@ Stream Claude output via Server-Sent Events.
 | Parameter | Type | Description |
 |---|---|---|
 | `prompt` | string | Required |
-| `workspace` | string | Workspace path |
+| `workdir` | string | Working directory inside container |
 | `session_id` | string | Session to resume |
 | `resume` | bool | Resume session |
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -26,6 +26,7 @@ Run Claude synchronously.
     "disallowed_tools": ["Write"],
     "output_format": "json",
     "max_budget_usd": 5.00,
+    "max_turns": 30,
     "dangerously_skip_permissions": false
   },
   "podman": {
@@ -35,6 +36,7 @@ Run Claude synchronously.
     "timeout": "5m",
     "memory": "512m",
     "cpus": "1",
+    "cpu_shares": 512,
     "lifecycle": {
       "on_create_command": ["pip install -r requirements.txt"],
       "post_create": ["npm run build"],
@@ -58,9 +60,12 @@ Run Claude synchronously.
   "id": "run-abc123def456",
   "status": "completed",
   "output": "Claude's response...",
+  "structured_output": {"key": "value"},
   "session_id": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+`structured_output` is populated when using `output_format: "json"` with a `json_schema`. It extracts the parsed JSON from Claude's response envelope.
 
 | Error Status | Cause |
 |---|---|
@@ -101,8 +106,10 @@ Run Claude asynchronously. Same request body as `/run`.
 ### Response
 
 ```json
-{"job_id": "job-abc123", "status": "pending"}
+{"job_id": "job-abc123", "session_id": "550e8400-e29b-41d4-a716-446655440000"}
 ```
+
+The `session_id` is returned immediately so you can use it for tracking or session resume even before the job completes.
 
 ---
 
@@ -129,13 +136,28 @@ Get job details.
   "id": "job-abc123",
   "status": "completed",
   "output": "...",
+  "structured_output": {"key": "value"},
   "session_id": "...",
+  "crash_info": null,
   "created_at": "...",
-  "completed_at": "..."
+  "updated_at": "..."
 }
 ```
 
-Job statuses: `pending`, `running`, `completed`, `failed`, `cancelled`
+Job statuses: `pending`, `running`, `completed`, `failed`, `crashed`, `cancelled`
+
+When a job crashes (e.g. OOM, timeout), `status` is `crashed` and `crash_info` contains details:
+
+```json
+{
+  "crash_info": {
+    "exit_code": 137,
+    "signal": "killed",
+    "partial_output": "last output before crash...",
+    "task_completed": false
+  }
+}
+```
 
 ---
 

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -28,6 +28,7 @@ sequenceDiagram
 4. **Claude CLI gets mounted** into the container from a separate CLI image. This means any glibc-based image works as a base.
 5. **Claude runs your prompt** inside the container, with access to whatever volumes you mounted.
 6. **Output comes back** as JSON, including a `session_id` you can use to continue the conversation later.
+7. **Container is cleaned up** — force-removed after execution even if `--rm` fails (e.g. after OOM kill or timeout).
 
 ## The two-image architecture
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -102,7 +102,7 @@ sequenceDiagram
     C->>A: POST /run/async
     A->>J: CreateJob()
     J-->>A: job_id
-    A-->>C: {job_id, status: pending}
+    A-->>C: {job_id, session_id}
 
     J->>R: Run(ctx, request)
     Note over R: Runs in background

--- a/docs/guides/client-examples.md
+++ b/docs/guides/client-examples.md
@@ -182,8 +182,9 @@ type PodmanOptions struct {
 }
 
 type RunResponse struct {
-	Output    string `json:"output"`
-	SessionID string `json:"session_id"`
+	Output           string          `json:"output"`
+	StructuredOutput json.RawMessage `json:"structured_output,omitempty"`
+	SessionID        string          `json:"session_id"`
 }
 
 func (c *Client) Run(ctx context.Context, req *RunRequest) (*RunResponse, error) {
@@ -214,6 +215,12 @@ func (c *Client) Run(ctx context.Context, req *RunRequest) (*RunResponse, error)
 //     Workdir: "/workspace",
 //     Podman:  &PodmanOptions{Volumes: []string{"/home/user/project:/workspace"}},
 // })
+//
+// // When using json_schema, check structured_output:
+// if result.StructuredOutput != nil {
+//     var data MyStruct
+//     json.Unmarshal(result.StructuredOutput, &data)
+// }
 ```
 
 ## CI/CD code review

--- a/docs/guides/client-examples.md
+++ b/docs/guides/client-examples.md
@@ -173,8 +173,9 @@ type RunRequest struct {
 }
 
 type ClaudeOptions struct {
-	Model        string  `json:"model,omitempty"`
-	MaxBudgetUSD float64 `json:"max_budget_usd,omitempty"`
+	Model        string   `json:"model,omitempty"`
+	MaxBudgetUSD *float64 `json:"max_budget_usd,omitempty"`
+	MaxTurns     *int     `json:"max_turns,omitempty"`
 }
 
 type PodmanOptions struct {

--- a/docs/guides/running-agents.md
+++ b/docs/guides/running-agents.md
@@ -72,6 +72,7 @@ curl -X POST localhost:8080/run \
 | `system_prompt` | string | Replace the default system prompt |
 | `append_system_prompt` | string | Append to the system prompt |
 | `max_budget_usd` | float | Max API cost for this run |
+| `max_turns` | int | Max agentic turns (0 = unlimited) |
 | `allowed_tools` | []string | Whitelist specific tools |
 | `disallowed_tools` | []string | Blacklist specific tools |
 | `output_format` | string | `text`, `json`, `stream-json` |
@@ -98,6 +99,7 @@ curl -X POST localhost:8080/run \
 | `memory` | string | Memory limit (`512m`, `2g`) |
 | `cpus` | string | CPU limit (`0.5`, `2`) |
 | `timeout` | string | Max runtime (`5m`, `1h`) |
+| `cpu_shares` | int | CPU shares (relative weight, default 1024) |
 | `image` | string | [Custom container image](custom-images.md) |
 | `volumes` | []string | Volume mounts (`host:container[:options]`) |
 | `secrets_env` | map | [Secrets](secrets.md) as env vars |
@@ -110,7 +112,7 @@ For long-running tasks, use async mode to avoid HTTP timeouts:
 # Start the job
 curl -X POST localhost:8080/run/async \
   -d '{"prompt": "Refactor the entire codebase", "workdir": "/workspace"}'
-# {"job_id": "job-abc123", "status": "pending"}
+# {"job_id": "job-abc123", "session_id": "550e8400-..."}
 
 # Check status
 curl localhost:8080/jobs/job-abc123

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1367,10 +1367,7 @@ const docTemplate = `{
                     "example": "running"
                 },
                 "structured_output": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
+                    "type": "object"
                 },
                 "updated_at": {
                     "type": "string",
@@ -1444,6 +1441,14 @@ const docTemplate = `{
             "description": "Response from Claude execution",
             "type": "object",
             "properties": {
+                "crash_info": {
+                    "description": "Crash details (when status is \"crashed\")",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/stromboli_internal_job.CrashInfo"
+                        }
+                    ]
+                },
                 "error": {
                     "description": "Error message (when failed)",
                     "type": "string",
@@ -1465,16 +1470,13 @@ const docTemplate = `{
                     "example": "sess-abc123def456"
                 },
                 "status": {
-                    "description": "Execution status: completed, error",
+                    "description": "Execution status: completed, crashed, error",
                     "type": "string",
                     "example": "completed"
                 },
                 "structured_output": {
                     "description": "Extracted structured_output from Claude's JSON envelope (when json_schema is used).\nConvenience field so callers don't need to parse the envelope themselves.",
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
+                    "type": "object"
                 }
             }
         },

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1018,6 +1018,10 @@ const docTemplate = `{
                 "job_id": {
                     "type": "string",
                     "example": "job-abc123def456"
+                },
+                "session_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
                 }
             }
         },
@@ -1362,6 +1366,12 @@ const docTemplate = `{
                     ],
                     "example": "running"
                 },
+                "structured_output": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "updated_at": {
                     "type": "string",
                     "example": "2024-01-15T10:31:00Z"
@@ -1445,7 +1455,7 @@ const docTemplate = `{
                     "example": "run-abc123def456"
                 },
                 "output": {
-                    "description": "Claude's output (when successful)",
+                    "description": "Claude's raw output (full CLI output, including JSON envelope when output_format=json)",
                     "type": "string",
                     "example": "Here is my analysis..."
                 },
@@ -1458,6 +1468,13 @@ const docTemplate = `{
                     "description": "Execution status: completed, error",
                     "type": "string",
                     "example": "completed"
+                },
+                "structured_output": {
+                    "description": "Extracted structured_output from Claude's JSON envelope (when json_schema is used).\nConvenience field so callers don't need to parse the envelope themselves.",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -2013,9 +2030,14 @@ const docTemplate = `{
                     "example": "{\"type\":\"object\"}"
                 },
                 "max_budget_usd": {
-                    "description": "Maximum dollar amount for API calls",
+                    "description": "Maximum dollar amount for API calls (pointer to distinguish 0 from unset)",
                     "type": "number",
                     "example": 5
+                },
+                "max_turns": {
+                    "description": "Maximum number of agentic turns (0 = unlimited, nil = use CLI default)",
+                    "type": "integer",
+                    "example": 30
                 },
                 "mcp_configs": {
                     "description": "MCP server config files or JSON strings",
@@ -2182,7 +2204,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "cpu_shares": {
-                    "description": "CPU shares (relative weight, default 1024)",
+                    "description": "CPU shares (relative weight, default 1024; pointer to distinguish 0 from unset)",
                     "type": "integer",
                     "example": 512
                 },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1361,10 +1361,7 @@
                     "example": "running"
                 },
                 "structured_output": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
+                    "type": "object"
                 },
                 "updated_at": {
                     "type": "string",
@@ -1438,6 +1435,14 @@
             "description": "Response from Claude execution",
             "type": "object",
             "properties": {
+                "crash_info": {
+                    "description": "Crash details (when status is \"crashed\")",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/stromboli_internal_job.CrashInfo"
+                        }
+                    ]
+                },
                 "error": {
                     "description": "Error message (when failed)",
                     "type": "string",
@@ -1459,16 +1464,13 @@
                     "example": "sess-abc123def456"
                 },
                 "status": {
-                    "description": "Execution status: completed, error",
+                    "description": "Execution status: completed, crashed, error",
                     "type": "string",
                     "example": "completed"
                 },
                 "structured_output": {
                     "description": "Extracted structured_output from Claude's JSON envelope (when json_schema is used).\nConvenience field so callers don't need to parse the envelope themselves.",
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
+                    "type": "object"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1012,6 +1012,10 @@
                 "job_id": {
                     "type": "string",
                     "example": "job-abc123def456"
+                },
+                "session_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
                 }
             }
         },
@@ -1356,6 +1360,12 @@
                     ],
                     "example": "running"
                 },
+                "structured_output": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "updated_at": {
                     "type": "string",
                     "example": "2024-01-15T10:31:00Z"
@@ -1439,7 +1449,7 @@
                     "example": "run-abc123def456"
                 },
                 "output": {
-                    "description": "Claude's output (when successful)",
+                    "description": "Claude's raw output (full CLI output, including JSON envelope when output_format=json)",
                     "type": "string",
                     "example": "Here is my analysis..."
                 },
@@ -1452,6 +1462,13 @@
                     "description": "Execution status: completed, error",
                     "type": "string",
                     "example": "completed"
+                },
+                "structured_output": {
+                    "description": "Extracted structured_output from Claude's JSON envelope (when json_schema is used).\nConvenience field so callers don't need to parse the envelope themselves.",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -2007,9 +2024,14 @@
                     "example": "{\"type\":\"object\"}"
                 },
                 "max_budget_usd": {
-                    "description": "Maximum dollar amount for API calls",
+                    "description": "Maximum dollar amount for API calls (pointer to distinguish 0 from unset)",
                     "type": "number",
                     "example": 5
+                },
+                "max_turns": {
+                    "description": "Maximum number of agentic turns (0 = unlimited, nil = use CLI default)",
+                    "type": "integer",
+                    "example": 30
                 },
                 "mcp_configs": {
                     "description": "MCP server config files or JSON strings",
@@ -2176,7 +2198,7 @@
             "type": "object",
             "properties": {
                 "cpu_shares": {
-                    "description": "CPU shares (relative weight, default 1024)",
+                    "description": "CPU shares (relative weight, default 1024; pointer to distinguish 0 from unset)",
                     "type": "integer",
                     "example": 512
                 },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -6,6 +6,9 @@ definitions:
       job_id:
         example: job-abc123def456
         type: string
+      session_id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
     type: object
   internal_api.ClaudeStatusResponse:
     description: Claude configuration status
@@ -249,6 +252,10 @@ definitions:
         allOf:
         - $ref: '#/definitions/stromboli_internal_job.Status'
         example: running
+      structured_output:
+        items:
+          type: integer
+        type: array
       updated_at:
         example: "2024-01-15T10:31:00Z"
         type: string
@@ -307,7 +314,8 @@ definitions:
         example: run-abc123def456
         type: string
       output:
-        description: Claude's output (when successful)
+        description: Claude's raw output (full CLI output, including JSON envelope
+          when output_format=json)
         example: Here is my analysis...
         type: string
       session_id:
@@ -318,6 +326,13 @@ definitions:
         description: 'Execution status: completed, error'
         example: completed
         type: string
+      structured_output:
+        description: |-
+          Extracted structured_output from Claude's JSON envelope (when json_schema is used).
+          Convenience field so callers don't need to parse the envelope themselves.
+        items:
+          type: integer
+        type: array
     type: object
   internal_api.SearchResultResponse:
     description: Search result from a container registry
@@ -724,9 +739,15 @@ definitions:
         example: '{"type":"object"}'
         type: string
       max_budget_usd:
-        description: Maximum dollar amount for API calls
+        description: Maximum dollar amount for API calls (pointer to distinguish 0
+          from unset)
         example: 5
         type: number
+      max_turns:
+        description: Maximum number of agentic turns (0 = unlimited, nil = use CLI
+          default)
+        example: 30
+        type: integer
       mcp_configs:
         description: MCP server config files or JSON strings
         items:
@@ -866,7 +887,8 @@ definitions:
     description: Podman container mount configuration
     properties:
       cpu_shares:
-        description: CPU shares (relative weight, default 1024)
+        description: CPU shares (relative weight, default 1024; pointer to distinguish
+          0 from unset)
         example: 512
         type: integer
       cpus:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -253,9 +253,7 @@ definitions:
         - $ref: '#/definitions/stromboli_internal_job.Status'
         example: running
       structured_output:
-        items:
-          type: integer
-        type: array
+        type: object
       updated_at:
         example: "2024-01-15T10:31:00Z"
         type: string
@@ -305,6 +303,10 @@ definitions:
   internal_api.RunResponse:
     description: Response from Claude execution
     properties:
+      crash_info:
+        allOf:
+        - $ref: '#/definitions/stromboli_internal_job.CrashInfo'
+        description: Crash details (when status is "crashed")
       error:
         description: Error message (when failed)
         example: ""
@@ -323,16 +325,14 @@ definitions:
         example: sess-abc123def456
         type: string
       status:
-        description: 'Execution status: completed, error'
+        description: 'Execution status: completed, crashed, error'
         example: completed
         type: string
       structured_output:
         description: |-
           Extracted structured_output from Claude's JSON envelope (when json_schema is used).
           Convenience field so callers don't need to parse the envelope themselves.
-        items:
-          type: integer
-        type: array
+        type: object
     type: object
   internal_api.SearchResultResponse:
     description: Search result from a container registry

--- a/internal/api/async.go
+++ b/internal/api/async.go
@@ -10,13 +10,15 @@ import (
 	"github.com/gin-gonic/gin"
 	"stromboli/internal/job"
 	"stromboli/internal/runner"
+	"stromboli/internal/session"
 	"stromboli/internal/webhook"
 )
 
 // AsyncRunResponse represents the response from starting an async run
 // @Description Response from starting an async Claude execution
 type AsyncRunResponse struct {
-	JobID string `json:"job_id" example:"job-abc123def456"`
+	JobID     string `json:"job_id" example:"job-abc123def456"`
+	SessionID string `json:"session_id" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 // JobResponse represents a job status response
@@ -61,8 +63,17 @@ func (s *Server) runAsync(c *gin.Context) {
 	}
 
 	jobID := generateJobID()
+
+	// Pre-generate session_id so it can be returned immediately for real-time tracking.
+	// If the caller provided one, use it; otherwise generate a new UUID.
+	sessionID := req.Claude.SessionID
+	if sessionID == "" {
+		sessionID = session.GenerateID()
+		req.Claude.SessionID = sessionID
+	}
+
 	s.jobMgr.Create(jobID)
-	s.jobMgr.Update(jobID, job.StatusRunning, "", "", "")
+	s.jobMgr.Update(jobID, job.StatusRunning, "", "", sessionID)
 
 	runnerReq := buildRunnerRequest(req)
 	webhookURL := req.WebhookURL
@@ -124,7 +135,8 @@ func (s *Server) runAsync(c *gin.Context) {
 	})
 
 	c.JSON(http.StatusAccepted, AsyncRunResponse{
-		JobID: jobID,
+		JobID:     jobID,
+		SessionID: sessionID,
 	})
 }
 

--- a/internal/api/async.go
+++ b/internal/api/async.go
@@ -28,7 +28,7 @@ type JobResponse struct {
 	ID               string          `json:"id" example:"job-abc123def456"`
 	Status           job.Status      `json:"status" example:"running"`
 	Output           string          `json:"output,omitempty" example:"Hello!"`
-	StructuredOutput json.RawMessage `json:"structured_output,omitempty"`
+	StructuredOutput json.RawMessage `json:"structured_output,omitempty" swaggertype:"object"`
 	Error            string          `json:"error,omitempty"`
 	SessionID        string          `json:"session_id,omitempty" example:"sess-abc123def456"`
 	CrashInfo        *job.CrashInfo  `json:"crash_info,omitempty"`

--- a/internal/api/async.go
+++ b/internal/api/async.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 
@@ -24,14 +25,15 @@ type AsyncRunResponse struct {
 // JobResponse represents a job status response
 // @Description Job status and result
 type JobResponse struct {
-	ID        string          `json:"id" example:"job-abc123def456"`
-	Status    job.Status      `json:"status" example:"running"`
-	Output    string          `json:"output,omitempty" example:"Hello!"`
-	Error     string          `json:"error,omitempty"`
-	SessionID string          `json:"session_id,omitempty" example:"sess-abc123def456"`
-	CrashInfo *job.CrashInfo  `json:"crash_info,omitempty"`
-	CreatedAt string          `json:"created_at" example:"2024-01-15T10:30:00Z"`
-	UpdatedAt string          `json:"updated_at" example:"2024-01-15T10:31:00Z"`
+	ID               string          `json:"id" example:"job-abc123def456"`
+	Status           job.Status      `json:"status" example:"running"`
+	Output           string          `json:"output,omitempty" example:"Hello!"`
+	StructuredOutput json.RawMessage `json:"structured_output,omitempty"`
+	Error            string          `json:"error,omitempty"`
+	SessionID        string          `json:"session_id,omitempty" example:"sess-abc123def456"`
+	CrashInfo        *job.CrashInfo  `json:"crash_info,omitempty"`
+	CreatedAt        string          `json:"created_at" example:"2024-01-15T10:30:00Z"`
+	UpdatedAt        string          `json:"updated_at" example:"2024-01-15T10:31:00Z"`
 }
 
 // JobListResponse represents a list of jobs
@@ -162,14 +164,15 @@ func (s *Server) getJob(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, JobResponse{
-		ID:        j.ID,
-		Status:    j.Status,
-		Output:    j.Output,
-		Error:     j.Error,
-		SessionID: j.SessionID,
-		CrashInfo: j.CrashInfo,
-		CreatedAt: j.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt: j.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		ID:               j.ID,
+		Status:           j.Status,
+		Output:           j.Output,
+		StructuredOutput: extractStructuredOutput(j.Output),
+		Error:            j.Error,
+		SessionID:        j.SessionID,
+		CrashInfo:        j.CrashInfo,
+		CreatedAt:        j.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:        j.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
 	})
 }
 
@@ -188,14 +191,15 @@ func (s *Server) listJobs(c *gin.Context) {
 	}
 	for _, j := range jobs {
 		resp.Jobs = append(resp.Jobs, &JobResponse{
-			ID:        j.ID,
-			Status:    j.Status,
-			Output:    j.Output,
-			Error:     j.Error,
-			SessionID: j.SessionID,
-			CrashInfo: j.CrashInfo,
-			CreatedAt: j.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-			UpdatedAt: j.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			ID:               j.ID,
+			Status:           j.Status,
+			Output:           j.Output,
+			StructuredOutput: extractStructuredOutput(j.Output),
+			Error:            j.Error,
+			SessionID:        j.SessionID,
+			CrashInfo:        j.CrashInfo,
+			CreatedAt:        j.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			UpdatedAt:        j.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
 		})
 	}
 

--- a/internal/api/async_test.go
+++ b/internal/api/async_test.go
@@ -260,6 +260,54 @@ func TestRunAsyncWithWebhook(t *testing.T) {
 		server.router.ServeHTTP(rec, req)
 
 		assert.Equal(t, http.StatusAccepted, rec.Code)
+
+		var response AsyncRunResponse
+		err = json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.SessionID, "session_id should be returned for real-time tracking")
+	})
+
+	t.Run("async returns session_id immediately and matches running job", func(t *testing.T) {
+		var capturedSessionID string
+		mockRunner := &runner.MockRunner{
+			RunAsyncFunc: func(ctx context.Context, req runner.Request, jobID string, onComplete func(*runner.Result, error)) {
+				capturedSessionID = req.Claude.SessionID
+				go func() {
+					time.Sleep(10 * time.Millisecond)
+					onComplete(&runner.Result{ID: "run-123", Output: "test", SessionID: capturedSessionID}, nil)
+				}()
+			},
+		}
+
+		server := newTestServer(t, mockRunner, true)
+
+		reqBody := map[string]interface{}{
+			"prompt": "test",
+		}
+		body, _ := json.Marshal(reqBody)
+
+		req, err := http.NewRequest(http.MethodPost, "/run/async", bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		rec := httptest.NewRecorder()
+		server.router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusAccepted, rec.Code)
+
+		var response AsyncRunResponse
+		err = json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		// session_id should be returned immediately
+		assert.NotEmpty(t, response.SessionID)
+		// session_id passed to runner should match the one returned
+		assert.Equal(t, response.SessionID, capturedSessionID)
+
+		// Running job should already have session_id
+		j, ok := server.jobMgr.Get(response.JobID)
+		require.True(t, ok)
+		assert.Equal(t, response.SessionID, j.SessionID)
 	})
 
 	t.Run("webhook failure does not affect job", func(t *testing.T) {

--- a/internal/api/run.go
+++ b/internal/api/run.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 
+	"stromboli/internal/job"
 	"stromboli/internal/types"
 )
 
@@ -47,17 +48,19 @@ type RunRequest struct {
 type RunResponse struct {
 	// Unique run identifier
 	ID string `json:"id" example:"run-abc123def456"`
-	// Execution status: completed, error
+	// Execution status: completed, crashed, error
 	Status string `json:"status" example:"completed"`
 	// Claude's raw output (full CLI output, including JSON envelope when output_format=json)
 	Output string `json:"output,omitempty" example:"Here is my analysis..."`
 	// Extracted structured_output from Claude's JSON envelope (when json_schema is used).
 	// Convenience field so callers don't need to parse the envelope themselves.
-	StructuredOutput json.RawMessage `json:"structured_output,omitempty"`
+	StructuredOutput json.RawMessage `json:"structured_output,omitempty" swaggertype:"object"`
 	// Error message (when failed)
 	Error string `json:"error,omitempty" example:""`
 	// Session ID for conversation continuation
 	SessionID string `json:"session_id,omitempty" example:"sess-abc123def456"`
+	// Crash details (when status is "crashed")
+	CrashInfo *job.CrashInfo `json:"crash_info,omitempty"`
 }
 
 // extractStructuredOutput parses Claude's JSON envelope and returns the

--- a/internal/api/run.go
+++ b/internal/api/run.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"encoding/json"
+
 	"stromboli/internal/types"
 )
 
@@ -47,12 +49,31 @@ type RunResponse struct {
 	ID string `json:"id" example:"run-abc123def456"`
 	// Execution status: completed, error
 	Status string `json:"status" example:"completed"`
-	// Claude's output (when successful)
+	// Claude's raw output (full CLI output, including JSON envelope when output_format=json)
 	Output string `json:"output,omitempty" example:"Here is my analysis..."`
+	// Extracted structured_output from Claude's JSON envelope (when json_schema is used).
+	// Convenience field so callers don't need to parse the envelope themselves.
+	StructuredOutput json.RawMessage `json:"structured_output,omitempty"`
 	// Error message (when failed)
 	Error string `json:"error,omitempty" example:""`
 	// Session ID for conversation continuation
 	SessionID string `json:"session_id,omitempty" example:"sess-abc123def456"`
+}
+
+// extractStructuredOutput parses Claude's JSON envelope and returns the
+// structured_output field if present. Returns nil if the output is not JSON
+// or doesn't contain structured_output.
+func extractStructuredOutput(output string) json.RawMessage {
+	var envelope struct {
+		StructuredOutput json.RawMessage `json:"structured_output"`
+	}
+	if err := json.Unmarshal([]byte(output), &envelope); err != nil {
+		return nil
+	}
+	if len(envelope.StructuredOutput) == 0 || string(envelope.StructuredOutput) == "null" {
+		return nil
+	}
+	return envelope.StructuredOutput
 }
 
 // SessionListResponse represents the response from listing sessions

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -209,12 +209,20 @@ func (s *Server) runClaude(c *gin.Context) {
 		return
 	}
 
+	status := "completed"
+	var crashInfo *job.CrashInfo
+	if result.CrashInfo != nil {
+		status = "crashed"
+		crashInfo = result.CrashInfo
+	}
+
 	c.JSON(http.StatusOK, RunResponse{
 		ID:               result.ID,
-		Status:           "completed",
+		Status:           status,
 		Output:           result.Output,
 		StructuredOutput: extractStructuredOutput(result.Output),
 		SessionID:        result.SessionID,
+		CrashInfo:        crashInfo,
 	})
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -210,10 +210,11 @@ func (s *Server) runClaude(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, RunResponse{
-		ID:        result.ID,
-		Status:    "completed",
-		Output:    result.Output,
-		SessionID: result.SessionID,
+		ID:               result.ID,
+		Status:           "completed",
+		Output:           result.Output,
+		StructuredOutput: extractStructuredOutput(result.Output),
+		SessionID:        result.SessionID,
 	})
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -319,7 +319,9 @@ func TestExtractStructuredOutput(t *testing.T) {
 		wantNil  bool
 		wantJSON string
 	}{
-		{"with structured_output", `{"result":"","structured_output":{"answer":4}}`, false, `{"answer":4}`},
+		{"with structured_output object", `{"result":"","structured_output":{"answer":4}}`, false, `{"answer":4}`},
+		{"with structured_output array", `{"result":"","structured_output":[1,2,3]}`, false, `[1,2,3]`},
+		{"with structured_output string", `{"result":"","structured_output":"hello"}`, false, `"hello"`},
 		{"without structured_output", `{"result":"hello"}`, true, ""},
 		{"plain text output", "Hello world", true, ""},
 		{"null structured_output", `{"result":"ok","structured_output":null}`, true, ""},

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -371,7 +371,8 @@ func TestRun_WithAllClaudeOptions(t *testing.T) {
 	assert.Equal(t, []string{"Write"}, capturedReq.Claude.DisallowedTools)
 	assert.Equal(t, "bypassPermissions", capturedReq.Claude.PermissionMode)
 	assert.Equal(t, "json", capturedReq.Claude.OutputFormat)
-	assert.Equal(t, 5.00, capturedReq.Claude.MaxBudgetUSD)
+	require.NotNil(t, capturedReq.Claude.MaxBudgetUSD)
+	assert.Equal(t, 5.00, *capturedReq.Claude.MaxBudgetUSD)
 	assert.True(t, capturedReq.Claude.Verbose)
 	assert.Equal(t, []string{"/data:/data:ro"}, capturedReq.Podman.Volumes)
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -312,6 +312,48 @@ func TestRun_WithStructuredOutput(t *testing.T) {
 	assert.Equal(t, float64(4), so["answer"])
 }
 
+func TestRun_WithCrashInfo(t *testing.T) {
+	mockRunner := &runner.MockRunner{
+		RunFunc: func(ctx context.Context, req runner.Request) (*runner.Result, error) {
+			return &runner.Result{
+				ID:        "run-crash",
+				Output:    "partial output before crash",
+				SessionID: "sess-crash",
+				CrashInfo: &job.CrashInfo{
+					ExitCode:      137,
+					Signal:        "killed",
+					Reason:        "OOM killed",
+					PartialOutput: "partial output before crash",
+					TaskCompleted: false,
+				},
+			}, nil
+		},
+	}
+
+	server := newTestServer(t, mockRunner, true)
+
+	body := bytes.NewBufferString(`{"prompt": "heavy task"}`)
+	req, err := http.NewRequest(http.MethodPost, "/run", body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response RunResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "crashed", response.Status)
+	assert.Equal(t, "partial output before crash", response.Output)
+	assert.NotNil(t, response.CrashInfo)
+	assert.Equal(t, 137, response.CrashInfo.ExitCode)
+	assert.Equal(t, "killed", response.CrashInfo.Signal)
+	assert.False(t, response.CrashInfo.TaskCompleted)
+}
+
 func TestExtractStructuredOutput(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -278,6 +278,66 @@ func TestRun_Success(t *testing.T) {
 	assert.Equal(t, "session-456", response.SessionID)
 }
 
+func TestRun_WithStructuredOutput(t *testing.T) {
+	// Claude CLI envelope with json_schema: result is empty, data in structured_output
+	envelopeOutput := `{"type":"result","subtype":"success","result":"","structured_output":{"answer":4}}`
+
+	mockRunner := &runner.MockRunner{
+		RunFunc: func(ctx context.Context, req runner.Request) (*runner.Result, error) {
+			return &runner.Result{ID: "run-so", Output: envelopeOutput, SessionID: "sess-so"}, nil
+		},
+	}
+
+	server := newTestServer(t, mockRunner, true)
+
+	body := bytes.NewBufferString(`{"prompt": "what is 2+2?", "claude": {"output_format": "json", "json_schema": "{}"}}`)
+	req, err := http.NewRequest(http.MethodPost, "/run", body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// Raw output should still be present
+	assert.Equal(t, envelopeOutput, response["output"])
+	// Structured output should be extracted from the envelope
+	so, ok := response["structured_output"].(map[string]interface{})
+	require.True(t, ok, "structured_output should be a JSON object")
+	assert.Equal(t, float64(4), so["answer"])
+}
+
+func TestExtractStructuredOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		wantNil  bool
+		wantJSON string
+	}{
+		{"with structured_output", `{"result":"","structured_output":{"answer":4}}`, false, `{"answer":4}`},
+		{"without structured_output", `{"result":"hello"}`, true, ""},
+		{"plain text output", "Hello world", true, ""},
+		{"null structured_output", `{"result":"ok","structured_output":null}`, true, ""},
+		{"empty string", "", true, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractStructuredOutput(tt.output)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				assert.JSONEq(t, tt.wantJSON, string(result))
+			}
+		})
+	}
+}
+
 func TestRun_WithWorkdir(t *testing.T) {
 	var capturedReq runner.Request
 	mockRunner := &runner.MockRunner{

--- a/internal/api/stream.go
+++ b/internal/api/stream.go
@@ -7,15 +7,18 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"stromboli/internal/job"
 	"stromboli/internal/runner"
 	"stromboli/internal/types"
 )
 
 // StreamResponse represents the final SSE event with result metadata
 type StreamResponse struct {
-	ID        string `json:"id"`
-	SessionID string `json:"session_id"`
-	Status    string `json:"status"`
+	ID               string          `json:"id"`
+	SessionID        string          `json:"session_id"`
+	Status           string          `json:"status"`
+	StructuredOutput json.RawMessage `json:"structured_output,omitempty" swaggertype:"object"`
+	CrashInfo        *job.CrashInfo  `json:"crash_info,omitempty"`
 }
 
 // runStream handles streaming Claude output via Server-Sent Events
@@ -112,10 +115,18 @@ waitForResult:
 	select {
 	case result := <-resultChan:
 		// Send final event with metadata
+		status := "completed"
+		var crashInfo *job.CrashInfo
+		if result.CrashInfo != nil {
+			status = "crashed"
+			crashInfo = result.CrashInfo
+		}
 		response := StreamResponse{
-			ID:        result.ID,
-			SessionID: result.SessionID,
-			Status:    "completed",
+			ID:               result.ID,
+			SessionID:        result.SessionID,
+			Status:           status,
+			StructuredOutput: extractStructuredOutput(result.Output),
+			CrashInfo:        crashInfo,
 		}
 
 		data, err := json.Marshal(response)

--- a/internal/claude/builder.go
+++ b/internal/claude/builder.go
@@ -46,8 +46,9 @@ type CommandBuilder struct {
 	// Structured output
 	jsonSchema string // --json-schema
 
-	// Budget control
-	maxBudgetUSD float64 // --max-budget-usd
+	// Budget & limits
+	maxBudgetUSD *float64 // --max-budget-usd
+	maxTurns     *int     // --max-turns
 
 	// MCP configuration
 	mcpConfigs      []string // --mcp-config
@@ -228,11 +229,17 @@ func (b *CommandBuilder) WithJSONSchema(schema string) *CommandBuilder {
 	return b
 }
 
-// --- Budget Control ---
+// --- Budget & Limits ---
 
 // WithMaxBudgetUSD sets maximum dollar amount for API calls
 func (b *CommandBuilder) WithMaxBudgetUSD(amount float64) *CommandBuilder {
-	b.maxBudgetUSD = amount
+	b.maxBudgetUSD = &amount
+	return b
+}
+
+// WithMaxTurns sets the maximum number of agentic turns (0 = unlimited)
+func (b *CommandBuilder) WithMaxTurns(turns int) *CommandBuilder {
+	b.maxTurns = &turns
 	return b
 }
 
@@ -418,9 +425,12 @@ func (b *CommandBuilder) Build() []string {
 		args = append(args, "--json-schema", b.jsonSchema)
 	}
 
-	// Budget control
-	if b.maxBudgetUSD > 0 {
-		args = append(args, "--max-budget-usd", fmt.Sprintf("%.2f", b.maxBudgetUSD))
+	// Budget & limits
+	if b.maxBudgetUSD != nil {
+		args = append(args, "--max-budget-usd", fmt.Sprintf("%.2f", *b.maxBudgetUSD))
+	}
+	if b.maxTurns != nil {
+		args = append(args, "--max-turns", fmt.Sprintf("%d", *b.maxTurns))
 	}
 
 	// MCP configuration

--- a/internal/claude/builder_test.go
+++ b/internal/claude/builder_test.go
@@ -210,6 +210,16 @@ func TestWithMaxBudgetUSD(t *testing.T) {
 	assert.Contains(t, cmd, "5.00")
 }
 
+func TestWithMaxBudgetUSD_Zero(t *testing.T) {
+	// Zero budget is a valid explicit value — must still be passed to CLI
+	cmd := NewCommandBuilder().
+		WithPrompt("hello").
+		WithMaxBudgetUSD(0.0).
+		Build()
+	assert.Contains(t, cmd, "--max-budget-usd")
+	assert.Contains(t, cmd, "0.00")
+}
+
 func TestWithMaxTurns(t *testing.T) {
 	cmd := NewCommandBuilder().
 		WithPrompt("hello").

--- a/internal/claude/builder_test.go
+++ b/internal/claude/builder_test.go
@@ -210,6 +210,25 @@ func TestWithMaxBudgetUSD(t *testing.T) {
 	assert.Contains(t, cmd, "5.00")
 }
 
+func TestWithMaxTurns(t *testing.T) {
+	cmd := NewCommandBuilder().
+		WithPrompt("hello").
+		WithMaxTurns(30).
+		Build()
+	assert.Contains(t, cmd, "--max-turns")
+	assert.Contains(t, cmd, "30")
+}
+
+func TestWithMaxTurns_Zero(t *testing.T) {
+	// Zero means unlimited — must still be passed to CLI
+	cmd := NewCommandBuilder().
+		WithPrompt("hello").
+		WithMaxTurns(0).
+		Build()
+	assert.Contains(t, cmd, "--max-turns")
+	assert.Contains(t, cmd, "0")
+}
+
 func TestWithMCPConfig(t *testing.T) {
 	cmd := NewCommandBuilder().
 		WithPrompt("test").

--- a/internal/history/reader.go
+++ b/internal/history/reader.go
@@ -61,19 +61,20 @@ type rawUsage struct {
 	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 }
 
-// findSessionFile locates the JSONL file for a session
+// findSessionFile locates the JSONL file for a session.
+// Claude Code names the project folder based on the container's workdir
+// (e.g. /workspace → -workspace, /project → -project), so we glob
+// for any folder name under .claude/projects/.
 func (r *Reader) findSessionFile(sessionID string) (string, error) {
-	// Session files are stored at: sessions/<sessionID>/.claude/projects/-workspace/<sessionID>.jsonl
-	sessionPath := filepath.Join(r.sessionsDir, sessionID, ".claude", "projects", "-workspace", sessionID+".jsonl")
-
-	if _, err := os.Stat(sessionPath); err != nil {
-		if os.IsNotExist(err) {
-			return "", fmt.Errorf("session history not found: %s", sessionID)
-		}
-		return "", fmt.Errorf("failed to access session file: %w", err)
+	pattern := filepath.Join(r.sessionsDir, sessionID, ".claude", "projects", "*", sessionID+".jsonl")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", fmt.Errorf("failed to search for session file: %w", err)
 	}
-
-	return sessionPath, nil
+	if len(matches) == 0 {
+		return "", fmt.Errorf("session history not found: %s", sessionID)
+	}
+	return matches[0], nil
 }
 
 // ListMessages returns a paginated list of messages for a session

--- a/internal/history/reader_test.go
+++ b/internal/history/reader_test.go
@@ -195,6 +195,43 @@ func TestReader_ListMessages_WithToolUse(t *testing.T) {
 	assert.Equal(t, "file1.txt\nfile2.txt", resultMsg.ToolResult.Stdout)
 }
 
+func TestReader_FindSessionFile_DifferentWorkdirs(t *testing.T) {
+	tmpDir := t.TempDir()
+	reader := NewReader(tmpDir)
+
+	tests := []struct {
+		name       string
+		workdirDir string // the Claude-generated project folder name
+	}{
+		{"default workspace", "-workspace"},
+		{"custom project dir", "-project"},
+		{"tmp workdir", "-tmp"},
+		{"nested workdir", "-home-user-code"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sessionID := "session-" + tt.workdirDir
+
+			// Create session directory with the workdir-specific path
+			sessionDir := filepath.Join(tmpDir, sessionID, ".claude", "projects", tt.workdirDir)
+			require.NoError(t, os.MkdirAll(sessionDir, 0755))
+
+			// Write a JSONL file
+			jsonlFile := filepath.Join(sessionDir, sessionID+".jsonl")
+			testData := `{"type":"user","uuid":"uuid-1","sessionId":"` + sessionID + `","timestamp":"2026-01-24T10:00:00.000Z","message":{"role":"user","content":"Hello"}}
+`
+			require.NoError(t, os.WriteFile(jsonlFile, []byte(testData), 0644))
+
+			// Should find the session regardless of workdir folder name
+			result, err := reader.ListMessages(sessionID, 0, 50)
+			require.NoError(t, err)
+			assert.Equal(t, 1, result.Total)
+			assert.Equal(t, "uuid-1", result.Messages[0].UUID)
+		})
+	}
+}
+
 func TestReader_ListMessages_LimitEnforcement(t *testing.T) {
 	tmpDir := t.TempDir()
 	reader := NewReader(tmpDir)

--- a/internal/podman/builder.go
+++ b/internal/podman/builder.go
@@ -16,7 +16,7 @@ type CommandBuilder struct {
 	command     []string
 	memory      string // memory limit (e.g., "512m", "1g")
 	cpus        string // CPU limit (e.g., "0.5", "2")
-	cpuShares   int    // CPU shares (relative weight)
+	cpuShares   *int   // CPU shares (relative weight)
 	user        string // user to run as (e.g., "1000:1000")
 	keepID      bool   // use --userns=keep-id for host user mapping
 }
@@ -162,7 +162,7 @@ func (b *CommandBuilder) WithCPUs(cpus string) *CommandBuilder {
 
 // WithCPUShares sets the CPU shares (relative weight, default 1024)
 func (b *CommandBuilder) WithCPUShares(shares int) *CommandBuilder {
-	b.cpuShares = shares
+	b.cpuShares = &shares
 	return b
 }
 
@@ -232,8 +232,8 @@ func (b *CommandBuilder) Build() []string {
 		args = append(args, "--cpus", b.cpus)
 	}
 
-	if b.cpuShares > 0 {
-		args = append(args, "--cpu-shares", fmt.Sprintf("%d", b.cpuShares))
+	if b.cpuShares != nil {
+		args = append(args, "--cpu-shares", fmt.Sprintf("%d", *b.cpuShares))
 	}
 
 	if b.image != "" {

--- a/internal/runner/cleanup.go
+++ b/internal/runner/cleanup.go
@@ -9,6 +9,27 @@ import (
 	"time"
 )
 
+// fetchContainerLogs retrieves the last maxBytes of logs from a container.
+// Used as a fallback when CombinedOutput() returns empty after a crash/timeout
+// (SIGKILL on the podman process can break the stdout relay before output is captured).
+func fetchContainerLogs(containerName string, maxBytes int) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "podman", "logs", "--tail", "200", containerName)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		slog.Debug("Failed to fetch container logs as crash output fallback", "name", containerName, "error", err)
+		return ""
+	}
+
+	logs := strings.TrimSpace(string(out))
+	if len(logs) > maxBytes {
+		return "..." + logs[len(logs)-maxBytes:]
+	}
+	return logs
+}
+
 // removeContainer force-removes a container by name.
 // Called via defer after execution to ensure cleanup even when --rm fails
 // (e.g. after SIGKILL from timeout or OOM). Errors are logged but not returned

--- a/internal/runner/cleanup.go
+++ b/internal/runner/cleanup.go
@@ -9,6 +9,23 @@ import (
 	"time"
 )
 
+// removeContainer force-removes a container by name.
+// Called via defer after execution to ensure cleanup even when --rm fails
+// (e.g. after SIGKILL from timeout or OOM). Errors are logged but not returned
+// because this runs in a defer and the primary result is already captured.
+func removeContainer(containerName string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "podman", "rm", "-f", containerName)
+	if err := cmd.Run(); err != nil {
+		// Ignore "no such container" — means --rm already cleaned it up
+		if !strings.Contains(err.Error(), "no such") {
+			slog.Warn("Failed to remove container after execution", "name", containerName, "error", err)
+		}
+	}
+}
+
 // CleanupOrphanedContainers removes any stromboli-agent containers that are still running
 // This should be called on server startup to clean up containers from previous runs
 func CleanupOrphanedContainers(ctx context.Context) error {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -345,6 +345,10 @@ func (r *PodmanRunner) Run(ctx context.Context, req Request) (*Result, error) {
 	metrics.IncActiveContainers()
 	defer metrics.DecActiveContainers()
 
+	// Ensure container is removed after execution, even if --rm fails
+	// (e.g. after SIGKILL from timeout or OOM kill)
+	defer removeContainer(containerName)
+
 	// Execute command using executor
 	output, err := r.executor.Run(ctx, fullCmd)
 	if err != nil {
@@ -532,6 +536,10 @@ func (r *PodmanRunner) RunStream(ctx context.Context, req Request, output chan<-
 	// Track active container
 	metrics.IncActiveContainers()
 	defer metrics.DecActiveContainers()
+
+	// Ensure container is removed after execution, even if --rm fails
+	// (e.g. after SIGKILL from timeout or OOM kill)
+	defer removeContainer(containerName)
 
 	// Execute command with streaming using executor
 	stdoutPipe, stderrPipe, start, wait, err := r.executor.RunStream(ctx, fullCmd)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -356,7 +356,14 @@ func (r *PodmanRunner) Run(ctx context.Context, req Request) (*Result, error) {
 
 		// Check if this is a crash (signal termination)
 		if IsCrash(err) {
-			crashInfo := ExtractCrashInfo(err, string(output))
+			// Fallback: if output is empty (SIGKILL broke the stdout relay),
+			// try fetching container logs directly from Podman
+			crashOutput := string(output)
+			if strings.TrimSpace(crashOutput) == "" {
+				crashOutput = fetchContainerLogs(containerName, 4000)
+			}
+
+			crashInfo := ExtractCrashInfo(err, crashOutput)
 			tracing.AddSpanAttributes(ctx,
 				"runner.crash", true,
 				"runner.crash_signal", crashInfo.Signal,
@@ -369,7 +376,7 @@ func (r *PodmanRunner) Run(ctx context.Context, req Request) (*Result, error) {
 			// This allows the caller to handle crashes differently
 			return &Result{
 				ID:        generateRunID(),
-				Output:    strings.TrimSpace(string(output)),
+				Output:    strings.TrimSpace(crashOutput),
 				SessionID: sessionID,
 				CrashInfo: crashInfo,
 			}, nil
@@ -596,7 +603,14 @@ func (r *PodmanRunner) RunStream(ctx context.Context, req Request, output chan<-
 
 		// Check if this is a crash (signal termination)
 		if IsCrash(cmdErr) {
-			crashInfo := ExtractCrashInfo(cmdErr, allOutput.String())
+			// Fallback: if streamed output is empty (SIGKILL broke pipes),
+			// try fetching container logs directly from Podman
+			crashOutput := allOutput.String()
+			if strings.TrimSpace(crashOutput) == "" {
+				crashOutput = fetchContainerLogs(containerName, 4000)
+			}
+
+			crashInfo := ExtractCrashInfo(cmdErr, crashOutput)
 			tracing.AddSpanAttributes(ctx,
 				"runner.crash", true,
 				"runner.crash_signal", crashInfo.Signal,
@@ -608,7 +622,7 @@ func (r *PodmanRunner) RunStream(ctx context.Context, req Request, output chan<-
 			// Return result with crash info instead of error
 			return &Result{
 				ID:        generateRunID(),
-				Output:    strings.TrimSpace(allOutput.String()),
+				Output:    strings.TrimSpace(crashOutput),
 				SessionID: sessionID,
 				CrashInfo: crashInfo,
 			}, nil

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -700,8 +700,8 @@ func (r *PodmanRunner) applyRequestConfig(req Request, podmanBuilder *podman.Com
 	if req.Podman.CPUs != "" {
 		podmanBuilder.WithCPUs(req.Podman.CPUs)
 	}
-	if req.Podman.CPUShares > 0 {
-		podmanBuilder.WithCPUShares(req.Podman.CPUShares)
+	if req.Podman.CPUShares != nil {
+		podmanBuilder.WithCPUShares(*req.Podman.CPUShares)
 	}
 
 	return nil
@@ -822,8 +822,11 @@ func (r *PodmanRunner) applyIOOptions(b *claude.CommandBuilder, opts types.Claud
 
 // applyResourceOptions handles MaxBudgetUSD, MCPConfigs, StrictMCPConfig, Agent, Agents, AddDirs, PluginDirs, Files, Settings, SettingSources, Betas options
 func (r *PodmanRunner) applyResourceOptions(b *claude.CommandBuilder, opts types.ClaudeOptions) {
-	if opts.MaxBudgetUSD > 0 {
-		b.WithMaxBudgetUSD(opts.MaxBudgetUSD)
+	if opts.MaxBudgetUSD != nil {
+		b.WithMaxBudgetUSD(*opts.MaxBudgetUSD)
+	}
+	if opts.MaxTurns != nil {
+		b.WithMaxTurns(*opts.MaxTurns)
 	}
 	if len(opts.MCPConfigs) > 0 {
 		b.WithMCPConfig(opts.MCPConfigs...)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -120,7 +120,7 @@ func TestRun_WithClaudeOptions(t *testing.T) {
 			PermissionMode:             "bypassPermissions",
 			DangerouslySkipPermissions: true,
 			OutputFormat:               "json",
-			MaxBudgetUSD:               5.00,
+			MaxBudgetUSD:               ptrFloat64(5.00),
 			Verbose:                    true,
 		},
 		Podman: types.PodmanOptions{
@@ -396,7 +396,7 @@ func TestRun_WithResourceLimits(t *testing.T) {
 		Podman: types.PodmanOptions{
 			Memory:    "512m",
 			CPUs:      "1.5",
-			CPUShares: 1024,
+			CPUShares: ptrInt(1024),
 		},
 	})
 
@@ -460,7 +460,7 @@ func TestRunStream_WithResourceLimits(t *testing.T) {
 		Podman: types.PodmanOptions{
 			Memory:    "1g",
 			CPUs:      "2",
-			CPUShares: 512,
+			CPUShares: ptrInt(512),
 		},
 	}, output)
 
@@ -618,3 +618,7 @@ func TestDefaultResourceLimits_StreamingAppliesDefaults(t *testing.T) {
 	// Expected to fail due to no podman container execution
 	assert.Error(t, err)
 }
+
+// Pointer helpers for test literals
+func ptrFloat64(v float64) *float64 { return &v }
+func ptrInt(v int) *int             { return &v }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -110,7 +110,7 @@ func TestRun_WithClaudeOptions(t *testing.T) {
 	// but it verifies the options are processed
 	_, err = runner.Run(context.Background(), Request{
 		Prompt:    "hello",
-		Workspace: "/project",
+		Workdir: "/project",
 		Claude: types.ClaudeOptions{
 			SessionID:                  "sess-123",
 			Model:                      "opus",

--- a/internal/types/options.go
+++ b/internal/types/options.go
@@ -64,10 +64,12 @@ type ClaudeOptions struct {
 	// JSON Schema for structured output validation
 	JSONSchema string `json:"json_schema,omitempty" example:"{\"type\":\"object\"}"`
 
-	// --- Budget Control ---
+	// --- Budget & Limits ---
 
-	// Maximum dollar amount for API calls
-	MaxBudgetUSD float64 `json:"max_budget_usd,omitempty" example:"5.00"`
+	// Maximum dollar amount for API calls (pointer to distinguish 0 from unset)
+	MaxBudgetUSD *float64 `json:"max_budget_usd,omitempty" example:"5.00"`
+	// Maximum number of agentic turns (0 = unlimited, nil = use CLI default)
+	MaxTurns *int `json:"max_turns,omitempty" example:"30"`
 
 	// --- MCP Configuration ---
 
@@ -194,8 +196,8 @@ type PodmanOptions struct {
 	// CPU limit (e.g., "0.5", "2")
 	CPUs string `json:"cpus,omitempty" example:"1"`
 
-	// CPU shares (relative weight, default 1024)
-	CPUShares int `json:"cpu_shares,omitempty" example:"512"`
+	// CPU shares (relative weight, default 1024; pointer to distinguish 0 from unset)
+	CPUShares *int `json:"cpu_shares,omitempty" example:"512"`
 
 	// Lifecycle hooks for running commands at specific container events
 	Lifecycle LifecycleHooks `json:"lifecycle,omitempty"`


### PR DESCRIPTION
## Summary

Batch fix for all 6 open issues, triaged by priority:

- **#35** — Session history reader hardcoded `-workspace` path → use `filepath.Glob` to find JSONL regardless of workdir
- **#39** — `max_turns=0` silently ignored (Go zero-value) → use `*int`/`*float64` pointer types, also adds missing `--max-turns` support
- **#38** — Orphaned containers after crash/timeout → `defer removeContainer()` in both `Run()` and `RunStream()` paths
- **#36** — Return `session_id` in async response → pre-generate before goroutine start for real-time tracking
- **#37** — `json_schema` result empty, data only in `structured_output` → extract convenience field from Claude CLI envelope
- **#40** — `crash_info.partial_output` always empty → `podman logs` fallback when SIGKILL breaks stdout relay

## ⚠️ Breaking Change

**`max_budget_usd: 0`** now has different semantics: previously `0` was silently ignored (treated as "unset"), now it's passed through to the CLI as `--max-budget-usd 0.00`. This is the intended fix (#39) — callers who relied on `0` being a no-op should omit the field instead. Same applies to `cpu_shares: 0` and the new `max_turns: 0` (unlimited turns).

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `TestReader_FindSessionFile_DifferentWorkdirs` — glob finds JSONL for various workdirs
- [x] `TestWithMaxTurns` + `TestWithMaxTurns_Zero` — new --max-turns flag including zero-value
- [x] `TestRunAsyncWithWebhook/async_returns_session_id_immediately_and_matches_running_job`
- [x] `TestRun_WithStructuredOutput` + `TestExtractStructuredOutput` — 7 edge cases
- [ ] Manual: Run async job with non-`/workspace` workdir, verify session messages work
- [ ] Manual: Trigger timeout, verify orphaned container is removed
- [ ] Manual: Trigger timeout/OOM, verify `crash_info.partial_output` is populated

Closes #35, closes #36, closes #37, closes #38, closes #39, closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)