### PR TITLE
ci: bump Go to 1.26 across workflows and Makefile

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.26'
 
       - name: Install go-licenses
         run: go install github.com/google/go-licenses@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.26'
           cache: true
 
       - name: Get version info

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.26'
 
       - name: Install swag
         run: go install github.com/swaggo/swag/cmd/swag@latest

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS=-ldflags "-X stromboli/internal/version.Version=$(VERSION) -X stromboli/internal/version.Commit=$(COMMIT) -X stromboli/internal/version.BuildTime=$(BUILD_TIME)"
 
 # Go container command - uses --userns=keep-id to preserve host file ownership
-GO_IMAGE=golang:1.24
+GO_IMAGE=golang:1.26
 GO_RUN=podman run --rm --userns=keep-id -v $(PWD):/app -w /app $(GO_IMAGE)
 
 # Build the application


### PR DESCRIPTION
## Summary
- Bumps `go-version: '1.24'` → `'1.26'` in `validate.yml`, `licenses.yml`, `release.yml`
- Bumps `GO_IMAGE=golang:1.24` → `golang:1.26` in the Makefile

## Why
Unblocks two open Dependabot PRs:
- **#57** raises `go.mod` to `go 1.25.0`, which fails the `OpenAPI Specs` job under Go 1.24
- **#32** bumps the Dockerfile builder images to `golang:1.26-alpine`

Aligning CI on 1.26 satisfies both.

## Test plan
- [ ] `validate.yml` (OpenAPI Specs + Documentation) green
- [ ] `licenses.yml` green
- [ ] No regressions in unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)