### PR TITLE
fix: enable auth + rate limiting by default with fail-fast secret check (#45)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-integration test-e2e test-all test-coverage lint dev clean claude-setup claude-check claude-status claude-logout secret-create secret-update secret-remove secret-status docs docs-swagger docs-godoc docs-serve docs-stop docs-logs build-claude-cli build-claude-cli-version licenses
+.PHONY: build run test test-integration test-e2e test-all test-coverage lint dev clean claude-setup claude-check claude-status claude-logout secret-create secret-update secret-remove secret-status docs docs-swagger docs-godoc docs-serve docs-stop docs-logs build-claude-cli build-claude-cli-version licenses gen-jwt-secret
 
 # Binary name
 BINARY=stromboli
@@ -354,6 +354,28 @@ container-setup: podman-socket-enable build-images secret-create container-start
 	@echo "  curl -X POST http://localhost:8080/run -H 'Content-Type: application/json' -d '{\"prompt\": \"Say hello\"}'"
 
 # ============================================================================
+# JWT Secret Generation
+# ============================================================================
+
+# Generate a JWT secret and append it to install/.env (creates the file if needed).
+# Use this once before the first `docker compose up` for a production deploy.
+gen-jwt-secret:
+	@if ! command -v openssl >/dev/null 2>&1; then \
+		echo "❌ openssl not found in PATH"; exit 1; \
+	fi
+	@SECRET="$$(openssl rand -base64 32)"; \
+		ENVFILE="install/.env"; \
+		if [ -f "$$ENVFILE" ] && grep -q '^STROMBOLI_JWT_SECRET=' "$$ENVFILE"; then \
+			echo "⚠️  STROMBOLI_JWT_SECRET already set in $$ENVFILE — refusing to overwrite."; \
+			echo "   Edit it manually or remove the existing line first."; \
+			exit 1; \
+		fi; \
+		mkdir -p install; \
+		printf 'STROMBOLI_JWT_SECRET=%s\n' "$$SECRET" >> "$$ENVFILE"; \
+		echo "✅ Generated JWT secret and wrote $$ENVFILE"; \
+		echo "   docker compose --env-file $$ENVFILE -f install/docker-compose.yml up -d"
+
+# ============================================================================
 # Licenses
 # ============================================================================
 
@@ -418,6 +440,9 @@ help:
 	@echo "Licenses:"
 	@echo "  licenses         Generate THIRD_PARTY_LICENSES file"
 	@echo "  licenses-check   Check if all dependency licenses are allowed"
+	@echo ""
+	@echo "Production setup:"
+	@echo "  gen-jwt-secret   Generate JWT secret and write install/.env"
 	@echo ""
 	@echo "Claude & Secrets:"
 	@echo "  claude-check     Verify Claude credentials exist"

--- a/install/README.md
+++ b/install/README.md
@@ -19,6 +19,9 @@ Works with both **Docker** and **Podman**.
 curl -O https://raw.githubusercontent.com/tomblancdev/stromboli/main/install/docker-compose.yml
 curl -O https://raw.githubusercontent.com/tomblancdev/stromboli/main/install/stromboli.example.yaml
 
+# Generate a JWT secret (required — auth is enabled by default)
+echo "STROMBOLI_JWT_SECRET=$(openssl rand -base64 32)" > .env
+
 # Start
 docker compose up -d   # or: podman-compose up -d
 
@@ -37,6 +40,13 @@ curl http://localhost:8080/health
 
 3. **Claude credentials** at `~/.claude/.credentials.json`
 
+4. **A JWT secret** — auth is on by default. Generate one with:
+   ```bash
+   echo "STROMBOLI_JWT_SECRET=$(openssl rand -base64 32)" > .env
+   ```
+   Compose-up refuses to start if the secret is unset, and Stromboli refuses
+   to start if it is empty, shorter than 32 chars, or a known placeholder.
+
 ## Configuration
 
 Edit `stromboli.example.yaml` or use environment variables:
@@ -46,7 +56,9 @@ Edit `stromboli.example.yaml` or use environment variables:
 | `STROMBOLI_SERVER_ADDRESS` | `:8080` | Listen address |
 | `STROMBOLI_RESOURCES_MEMORY` | `512m` | Memory per agent |
 | `STROMBOLI_RESOURCES_TIMEOUT` | `30m` | Execution timeout |
-| `STROMBOLI_AUTH_ENABLED` | `false` | Enable auth |
+| `STROMBOLI_AUTH_ENABLED` | `true` | Auth on by default. Set `false` only for local dev. |
+| `STROMBOLI_JWT_SECRET` | _(required when auth on)_ | Min 32 chars; generate with `openssl rand -base64 32`. |
+| `STROMBOLI_RATE_LIMIT_ENABLED` | `true` | Rate limiting on by default. |
 
 ## API Usage
 

--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -3,14 +3,27 @@
 # =============================================================================
 #
 # Quick Start:
-#   1. Ensure Claude credentials exist: ~/.claude/.credentials.json
-#   2. Start: docker compose up -d  (or: podman-compose up -d)
-#   3. Check health: curl http://localhost:8080/health
+#   1. Generate a JWT secret:
+#        echo "STROMBOLI_JWT_SECRET=$(openssl rand -base64 32)" > .env
+#      (or run: make gen-jwt-secret)
+#
+#   2. Ensure Claude credentials exist: ~/.claude/.credentials.json
+#
+#   3. Start: docker compose up -d  (or: podman-compose up -d)
+#
+#   4. Check health: curl http://localhost:8080/health
 #
 # Requirements:
 #   - Podman with socket enabled: systemctl --user enable --now podman.socket
 #   - OR Docker (comment out userns_mode line)
 #   - Claude Code credentials (~/.claude/.credentials.json)
+#
+# Security note:
+#   Auth and rate limiting are ENABLED by default. The compose file refuses to
+#   start if STROMBOLI_JWT_SECRET is unset (?err: syntax). The Stromboli server
+#   will also refuse to start if the secret is empty, too short (<32 chars), or
+#   a known placeholder value. To run without auth (e.g. local dev), set
+#   STROMBOLI_AUTH_ENABLED=false explicitly.
 #
 # =============================================================================
 
@@ -77,19 +90,21 @@ services:
       STROMBOLI_RESOURCES_TIMEOUT: "30m"
 
       # -------------------------------------------------------------------------
-      # Authentication (enable for production!)
+      # Authentication (enabled by default — secure-by-default)
       # -------------------------------------------------------------------------
-      STROMBOLI_AUTH_ENABLED: "false"
-      # STROMBOLI_JWT_SECRET: "generate-with-openssl-rand-base64-32"
-      # STROMBOLI_JWT_EXPIRY: "24h"
-      # STROMBOLI_JWT_REFRESH_EXPIRY: "168h"
+      # The ?err syntax fails compose-up if STROMBOLI_JWT_SECRET is unset.
+      # Generate one with: openssl rand -base64 32 (or `make gen-jwt-secret`).
+      STROMBOLI_AUTH_ENABLED: "true"
+      STROMBOLI_JWT_SECRET: "${STROMBOLI_JWT_SECRET:?STROMBOLI_JWT_SECRET is required — generate one with: openssl rand -base64 32}"
+      STROMBOLI_JWT_EXPIRY: "24h"
+      STROMBOLI_JWT_REFRESH_EXPIRY: "168h"
 
       # -------------------------------------------------------------------------
-      # Rate Limiting (enable for production!)
+      # Rate Limiting (enabled by default)
       # -------------------------------------------------------------------------
-      STROMBOLI_RATE_LIMIT_ENABLED: "false"
-      # STROMBOLI_RATE_LIMIT_RPS: "10"
-      # STROMBOLI_RATE_LIMIT_BURST: "20"
+      STROMBOLI_RATE_LIMIT_ENABLED: "true"
+      STROMBOLI_RATE_LIMIT_RPS: "10"
+      STROMBOLI_RATE_LIMIT_BURST: "20"
 
       # -------------------------------------------------------------------------
       # Job Cleanup
@@ -121,28 +136,18 @@ volumes:
     driver: local
 
 # =============================================================================
-# Production Deployment
+# Tightening rate limits for production
 # =============================================================================
 #
-# 1. Create docker-compose.override.yml:
+# The defaults above are sized for a small team. For production traffic, raise
+# them via a docker-compose.override.yml:
 #
 #    services:
 #      stromboli:
 #        environment:
-#          STROMBOLI_AUTH_ENABLED: "true"
-#          STROMBOLI_JWT_SECRET: "${JWT_SECRET}"
-#          STROMBOLI_RATE_LIMIT_ENABLED: "true"
 #          STROMBOLI_RATE_LIMIT_RPS: "50"
 #          STROMBOLI_RATE_LIMIT_BURST: "100"
 #          STROMBOLI_RESOURCES_MEMORY: "2g"
 #          STROMBOLI_RESOURCES_CPUS: "2"
-#
-# 2. Create .env file:
-#
-#    JWT_SECRET=your-secure-random-secret-generated-with-openssl
-#
-# 3. Start:
-#
-#    docker compose up -d
 #
 # =============================================================================

--- a/install/stromboli.example.yaml
+++ b/install/stromboli.example.yaml
@@ -115,9 +115,11 @@ resources:
 # Authentication
 # -----------------------------------------------------------------------------
 auth:
-  # Enable authentication (strongly recommended for production)
+  # Authentication is ENABLED by default (secure-by-default).
+  # Stromboli refuses to start if `jwt.secret` is empty, < 32 chars, or a
+  # known placeholder. Set this to `false` only for local development.
   # Env: STROMBOLI_AUTH_ENABLED
-  enabled: false
+  enabled: true
 
   # Static API tokens (legacy - use JWT for production)
   # Env: STROMBOLI_API_TOKENS (comma-separated)
@@ -125,10 +127,10 @@ auth:
     # - "your-api-token-here"
 
 # -----------------------------------------------------------------------------
-# JWT Authentication (Recommended for Production)
+# JWT Authentication (required when auth is enabled)
 # -----------------------------------------------------------------------------
 jwt:
-  # Secret key for signing JWT tokens
+  # Secret key for signing JWT tokens. Required when auth.enabled = true.
   # Generate with: openssl rand -base64 32
   # Env: STROMBOLI_JWT_SECRET
   secret: ""
@@ -145,9 +147,9 @@ jwt:
 # Rate Limiting
 # -----------------------------------------------------------------------------
 rate_limit:
-  # Enable rate limiting
+  # Rate limiting is ENABLED by default. Tune `rate`/`burst` below.
   # Env: STROMBOLI_RATE_LIMIT_ENABLED
-  enabled: false
+  enabled: true
 
   # Requests per second
   # Env: STROMBOLI_RATE_LIMIT_RPS

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,11 @@ const (
 	defaultTracingEndpoint   = "localhost:4317"
 	defaultTracingService    = "stromboli"
 
+	// MinJWTSecretLength is the minimum allowed JWT secret length in bytes.
+	// 32 bytes matches the output of `openssl rand -base64 24` (32 chars) and
+	// gives at least 192 bits of entropy when generated from random bytes.
+	MinJWTSecretLength = 32
+
 	// Compose defaults
 	defaultComposeBuildTimeout  = 10 * time.Minute
 	defaultComposeHealthTimeout = 2 * time.Minute
@@ -197,7 +202,10 @@ func setupViper(v *viper.Viper) {
 	v.SetDefault("resources.memory", defaultMemory)
 	v.SetDefault("resources.cpus", defaultCPUs)
 	v.SetDefault("resources.timeout", defaultTimeout)
-	v.SetDefault("auth.enabled", false)
+	// Auth is on by default — secure-by-default.
+	// Operators must provide STROMBOLI_JWT_SECRET; Validate() refuses to start otherwise.
+	// Local dev that wants to skip auth must set STROMBOLI_AUTH_ENABLED=false explicitly.
+	v.SetDefault("auth.enabled", true)
 	v.SetDefault("auth.valid_tokens", []string{})
 	v.SetDefault("rate_limit.enabled", false)
 	v.SetDefault("rate_limit.rate", defaultRateLimitRate)
@@ -472,6 +480,15 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// When auth is enabled, the JWT secret must be present, long enough, and not a
+	// known placeholder. This is the secure-by-default gate: a misconfigured prod
+	// deploy fails to start instead of silently exposing an unauthenticated API.
+	if c.Auth.Enabled {
+		if err := validateJWTSecret(c.JWT.Secret); err != nil {
+			return err
+		}
+	}
+
 	// Validate job cleanup config
 	if c.Jobs.CleanupTTL <= 0 {
 		return fmt.Errorf("job cleanup TTL must be positive")
@@ -501,5 +518,37 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("compose stack TTL must be positive")
 	}
 
+	return nil
+}
+
+// jwtPlaceholderSecrets are well-known placeholder strings shipped in templates
+// and documentation. Treating them as invalid prevents an operator from
+// accidentally promoting a copy-pasted example to production.
+var jwtPlaceholderSecrets = map[string]struct{}{
+	"change-me":                              {},
+	"changeme":                               {},
+	"replace-me":                             {},
+	"your-secret-here":                       {},
+	"your-jwt-secret":                        {},
+	"generate-with-openssl-rand-base64-32":   {},
+	"insecure-secret-do-not-use-in-prod":     {},
+	"test-secret":                            {},
+}
+
+// validateJWTSecret enforces the JWT secret requirements when auth is enabled.
+// Returns an actionable error directing the operator to generate a real secret.
+func validateJWTSecret(secret string) error {
+	const howToFix = "generate one with: openssl rand -base64 32"
+
+	if secret == "" {
+		return fmt.Errorf("auth is enabled but STROMBOLI_JWT_SECRET is empty — %s", howToFix)
+	}
+	if len(secret) < MinJWTSecretLength {
+		return fmt.Errorf("auth is enabled but STROMBOLI_JWT_SECRET is too short (%d chars, need at least %d) — %s",
+			len(secret), MinJWTSecretLength, howToFix)
+	}
+	if _, isPlaceholder := jwtPlaceholderSecrets[strings.ToLower(strings.TrimSpace(secret))]; isPlaceholder {
+		return fmt.Errorf("auth is enabled but STROMBOLI_JWT_SECRET is a known placeholder value — %s", howToFix)
+	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,15 +13,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// validJWTSecret is a 44-char base64 string used in tests where we need auth to
-// pass validation. Generated with `openssl rand -base64 32`.
-const validJWTSecret = "qY3FvR0xUd5HxN6tA8bC9eK2mZ4pL7vJ8sQ1wE3rT5o="
+// newTestJWTSecret returns a fresh random base64 string suitable for satisfying
+// the JWT secret validation in tests. Generating it at runtime (rather than
+// embedding a literal) keeps secret-scanners from flagging the test fixture.
+func newTestJWTSecret(t *testing.T) string {
+	t.Helper()
+	b := make([]byte, 32)
+	_, err := rand.Read(b)
+	require.NoError(t, err)
+	return base64.StdEncoding.EncodeToString(b)
+}
 
 func TestLoad_Defaults(t *testing.T) {
 	// Clean environment, then provide a valid JWT secret so the secure-by-default
 	// auth check passes — we still want to verify the *other* defaults below.
 	cleanEnv(t)
-	t.Setenv("STROMBOLI_JWT_SECRET", validJWTSecret)
+	secret := newTestJWTSecret(t)
+	t.Setenv("STROMBOLI_JWT_SECRET", secret)
 
 	cfg, err := Load()
 	require.NoError(t, err)
@@ -47,7 +58,7 @@ func TestLoad_Defaults(t *testing.T) {
 	assert.Equal(t, time.Second, cfg.RateLimit.Period)
 
 	// Test JWT defaults (secret was injected above; durations come from defaults)
-	assert.Equal(t, validJWTSecret, cfg.JWT.Secret)
+	assert.Equal(t, secret, cfg.JWT.Secret)
 	assert.Equal(t, 24*time.Hour, cfg.JWT.AccessExpiry)
 	assert.Equal(t, 7*24*time.Hour, cfg.JWT.RefreshExpiry)
 
@@ -62,6 +73,7 @@ func TestLoad_Defaults(t *testing.T) {
 
 func TestLoad_EnvironmentVariables(t *testing.T) {
 	cleanEnv(t)
+	secret := newTestJWTSecret(t)
 
 	// Set environment variables
 	os.Setenv("STROMBOLI_SERVER_ADDRESS", ":9090")
@@ -76,7 +88,7 @@ func TestLoad_EnvironmentVariables(t *testing.T) {
 	os.Setenv("STROMBOLI_RATE_LIMIT_ENABLED", "true")
 	os.Setenv("STROMBOLI_RATE_LIMIT_RPS", "50")
 	os.Setenv("STROMBOLI_RATE_LIMIT_BURST", "100")
-	os.Setenv("STROMBOLI_JWT_SECRET", validJWTSecret)
+	os.Setenv("STROMBOLI_JWT_SECRET", secret)
 	os.Setenv("STROMBOLI_JWT_EXPIRY", "12h")
 	os.Setenv("STROMBOLI_JWT_REFRESH_EXPIRY", "72h")
 	os.Setenv("STROMBOLI_TOKEN_CACHE_ENABLED", "false")
@@ -97,7 +109,7 @@ func TestLoad_EnvironmentVariables(t *testing.T) {
 	assert.True(t, cfg.RateLimit.Enabled)
 	assert.Equal(t, 50, cfg.RateLimit.Rate)
 	assert.Equal(t, 100, cfg.RateLimit.Burst)
-	assert.Equal(t, validJWTSecret, cfg.JWT.Secret)
+	assert.Equal(t, secret, cfg.JWT.Secret)
 	assert.Equal(t, 12*time.Hour, cfg.JWT.AccessExpiry)
 	assert.Equal(t, 72*time.Hour, cfg.JWT.RefreshExpiry)
 	assert.False(t, cfg.Agent.TokenCache.Enabled)
@@ -107,9 +119,10 @@ func TestLoad_EnvironmentVariables(t *testing.T) {
 func TestLoad_BackwardCompatibility(t *testing.T) {
 	// Test that legacy env vars still work
 	cleanEnv(t)
+	secret := newTestJWTSecret(t)
 
 	os.Setenv("STROMBOLI_AUTH_ENABLED", "true")
-	os.Setenv("STROMBOLI_JWT_SECRET", validJWTSecret)
+	os.Setenv("STROMBOLI_JWT_SECRET", secret)
 	os.Setenv("STROMBOLI_API_TOKENS", "legacy1,legacy2")
 	os.Setenv("STROMBOLI_RATE_LIMIT_ENABLED", "true")
 	os.Setenv("STROMBOLI_RATE_LIMIT_RPS", "25")
@@ -133,12 +146,13 @@ func TestLoad_BackwardCompatibility(t *testing.T) {
 
 func TestLoad_ConfigFile(t *testing.T) {
 	cleanEnv(t)
+	secret := newTestJWTSecret(t)
 
 	// Create temporary config file
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "stromboli.yaml")
 
-	configContent := `
+	configContent := fmt.Sprintf(`
 server:
   address: ":7070"
 
@@ -167,14 +181,14 @@ rate_limit:
   burst: 200
 
 jwt:
-  secret: "qY3FvR0xUd5HxN6tA8bC9eK2mZ4pL7vJ8sQ1wE3rT5o="
+  secret: %q
   access_expiry: "6h"
   refresh_expiry: "48h"
 
 jobs:
   cleanup_ttl: "2h"
   cleanup_interval: "10m"
-`
+`, secret)
 	err := os.WriteFile(configPath, []byte(configContent), 0644)
 	require.NoError(t, err)
 
@@ -194,7 +208,7 @@ jobs:
 	assert.True(t, cfg.RateLimit.Enabled)
 	assert.Equal(t, 100, cfg.RateLimit.Rate)
 	assert.Equal(t, 200, cfg.RateLimit.Burst)
-	assert.Equal(t, validJWTSecret, cfg.JWT.Secret)
+	assert.Equal(t, secret, cfg.JWT.Secret)
 	assert.Equal(t, 6*time.Hour, cfg.JWT.AccessExpiry)
 	assert.Equal(t, 48*time.Hour, cfg.JWT.RefreshExpiry)
 	assert.Equal(t, 2*time.Hour, cfg.Jobs.CleanupTTL)
@@ -225,7 +239,7 @@ auth:
 	// Override with environment variables
 	os.Setenv("STROMBOLI_SERVER_ADDRESS", ":8888")
 	os.Setenv("STROMBOLI_AUTH_ENABLED", "true")
-	os.Setenv("STROMBOLI_JWT_SECRET", validJWTSecret)
+	os.Setenv("STROMBOLI_JWT_SECRET", newTestJWTSecret(t))
 	os.Setenv("STROMBOLI_API_TOKENS", "env-token")
 
 	cfg, err := LoadFromFile(configPath)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,9 +10,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// validJWTSecret is a 44-char base64 string used in tests where we need auth to
+// pass validation. Generated with `openssl rand -base64 32`.
+const validJWTSecret = "qY3FvR0xUd5HxN6tA8bC9eK2mZ4pL7vJ8sQ1wE3rT5o="
+
 func TestLoad_Defaults(t *testing.T) {
-	// Clean environment
+	// Clean environment, then provide a valid JWT secret so the secure-by-default
+	// auth check passes — we still want to verify the *other* defaults below.
 	cleanEnv(t)
+	t.Setenv("STROMBOLI_JWT_SECRET", validJWTSecret)
 
 	cfg, err := Load()
 	require.NoError(t, err)
@@ -30,8 +36,8 @@ func TestLoad_Defaults(t *testing.T) {
 	assert.Equal(t, "1", cfg.Resources.CPUs)
 	assert.Equal(t, "30m", cfg.Resources.Timeout)
 
-	// Test auth defaults (disabled)
-	assert.False(t, cfg.Auth.Enabled)
+	// Test auth defaults (enabled — secure by default)
+	assert.True(t, cfg.Auth.Enabled)
 	assert.Empty(t, cfg.Auth.ValidTokens)
 
 	// Test rate limit defaults (disabled)
@@ -40,8 +46,8 @@ func TestLoad_Defaults(t *testing.T) {
 	assert.Equal(t, 20, cfg.RateLimit.Burst)
 	assert.Equal(t, time.Second, cfg.RateLimit.Period)
 
-	// Test JWT defaults
-	assert.Empty(t, cfg.JWT.Secret)
+	// Test JWT defaults (secret was injected above; durations come from defaults)
+	assert.Equal(t, validJWTSecret, cfg.JWT.Secret)
 	assert.Equal(t, 24*time.Hour, cfg.JWT.AccessExpiry)
 	assert.Equal(t, 7*24*time.Hour, cfg.JWT.RefreshExpiry)
 
@@ -70,7 +76,7 @@ func TestLoad_EnvironmentVariables(t *testing.T) {
 	os.Setenv("STROMBOLI_RATE_LIMIT_ENABLED", "true")
 	os.Setenv("STROMBOLI_RATE_LIMIT_RPS", "50")
 	os.Setenv("STROMBOLI_RATE_LIMIT_BURST", "100")
-	os.Setenv("STROMBOLI_JWT_SECRET", "test-secret")
+	os.Setenv("STROMBOLI_JWT_SECRET", validJWTSecret)
 	os.Setenv("STROMBOLI_JWT_EXPIRY", "12h")
 	os.Setenv("STROMBOLI_JWT_REFRESH_EXPIRY", "72h")
 	os.Setenv("STROMBOLI_TOKEN_CACHE_ENABLED", "false")
@@ -91,7 +97,7 @@ func TestLoad_EnvironmentVariables(t *testing.T) {
 	assert.True(t, cfg.RateLimit.Enabled)
 	assert.Equal(t, 50, cfg.RateLimit.Rate)
 	assert.Equal(t, 100, cfg.RateLimit.Burst)
-	assert.Equal(t, "test-secret", cfg.JWT.Secret)
+	assert.Equal(t, validJWTSecret, cfg.JWT.Secret)
 	assert.Equal(t, 12*time.Hour, cfg.JWT.AccessExpiry)
 	assert.Equal(t, 72*time.Hour, cfg.JWT.RefreshExpiry)
 	assert.False(t, cfg.Agent.TokenCache.Enabled)
@@ -103,6 +109,7 @@ func TestLoad_BackwardCompatibility(t *testing.T) {
 	cleanEnv(t)
 
 	os.Setenv("STROMBOLI_AUTH_ENABLED", "true")
+	os.Setenv("STROMBOLI_JWT_SECRET", validJWTSecret)
 	os.Setenv("STROMBOLI_API_TOKENS", "legacy1,legacy2")
 	os.Setenv("STROMBOLI_RATE_LIMIT_ENABLED", "true")
 	os.Setenv("STROMBOLI_RATE_LIMIT_RPS", "25")
@@ -160,7 +167,7 @@ rate_limit:
   burst: 200
 
 jwt:
-  secret: "file-jwt-secret"
+  secret: "qY3FvR0xUd5HxN6tA8bC9eK2mZ4pL7vJ8sQ1wE3rT5o="
   access_expiry: "6h"
   refresh_expiry: "48h"
 
@@ -187,7 +194,7 @@ jobs:
 	assert.True(t, cfg.RateLimit.Enabled)
 	assert.Equal(t, 100, cfg.RateLimit.Rate)
 	assert.Equal(t, 200, cfg.RateLimit.Burst)
-	assert.Equal(t, "file-jwt-secret", cfg.JWT.Secret)
+	assert.Equal(t, validJWTSecret, cfg.JWT.Secret)
 	assert.Equal(t, 6*time.Hour, cfg.JWT.AccessExpiry)
 	assert.Equal(t, 48*time.Hour, cfg.JWT.RefreshExpiry)
 	assert.Equal(t, 2*time.Hour, cfg.Jobs.CleanupTTL)
@@ -218,6 +225,7 @@ auth:
 	// Override with environment variables
 	os.Setenv("STROMBOLI_SERVER_ADDRESS", ":8888")
 	os.Setenv("STROMBOLI_AUTH_ENABLED", "true")
+	os.Setenv("STROMBOLI_JWT_SECRET", validJWTSecret)
 	os.Setenv("STROMBOLI_API_TOKENS", "env-token")
 
 	cfg, err := LoadFromFile(configPath)
@@ -264,11 +272,16 @@ func TestLoad_TokenCacheInvalidTTL(t *testing.T) {
 func TestLoad_TokenCacheEnabledWithoutTTL(t *testing.T) {
 	cleanEnv(t)
 
-	// Create temporary config file with cache enabled but TTL = 0
+	// Create temporary config file with cache enabled but TTL = 0.
+	// Disable auth so the validation we're testing is the token-cache one,
+	// not the JWT-secret gate.
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "stromboli.yaml")
 
 	configContent := `
+auth:
+  enabled: false
+
 agent:
   token_cache:
     enabled: true
@@ -280,6 +293,41 @@ agent:
 	_, err = LoadFromFile(configPath)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "token cache TTL must be positive when cache is enabled")
+}
+
+func TestLoad_AuthEnabledRequiresJWTSecret(t *testing.T) {
+	cleanEnv(t)
+	// Auth is on by default; no JWT_SECRET set → must fail.
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "STROMBOLI_JWT_SECRET is empty")
+	assert.Contains(t, err.Error(), "openssl rand -base64 32")
+}
+
+func TestLoad_AuthDisabledAllowsEmptyJWTSecret(t *testing.T) {
+	cleanEnv(t)
+	t.Setenv("STROMBOLI_AUTH_ENABLED", "false")
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.False(t, cfg.Auth.Enabled)
+	assert.Empty(t, cfg.JWT.Secret)
+}
+
+func TestLoad_AuthEnabledRejectsShortJWTSecret(t *testing.T) {
+	cleanEnv(t)
+	t.Setenv("STROMBOLI_JWT_SECRET", "short")
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
+}
+
+func TestLoad_AuthEnabledRejectsPlaceholderJWTSecret(t *testing.T) {
+	cleanEnv(t)
+	// Long enough to pass the length check, but a known placeholder value.
+	t.Setenv("STROMBOLI_JWT_SECRET", "generate-with-openssl-rand-base64-32")
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "placeholder")
 }
 
 // cleanEnv removes all STROMBOLI_ environment variables for testing


### PR DESCRIPTION
## Summary
- **Secure-by-default auth at three layers:**
  - **Binary defaults:** `auth.enabled` flips to `true`. `Validate()` refuses to start when auth is on and the JWT secret is empty, < 32 chars, or one of several known placeholder strings.
  - **Compose template:** `install/docker-compose.yml` flips `AUTH_ENABLED` + `RATE_LIMIT_ENABLED` to `true`. `STROMBOLI_JWT_SECRET` uses `\${VAR:?msg}` so `docker compose up` itself refuses to start without one, with an actionable error.
  - **Operator UX:** new `make gen-jwt-secret` target writes a random secret to `install/.env` (refuses to overwrite an existing one). README + example yaml updated.
- Closes #45

## Behavior change
**Existing deployments using `install/docker-compose.yml` without explicit `STROMBOLI_AUTH_ENABLED=false` will refuse to start until they set `STROMBOLI_JWT_SECRET`.** This is intended — the failure mode is loud rather than silent.

Local dev that wants no auth must now set `STROMBOLI_AUTH_ENABLED=false` explicitly.

## Test plan
- [x] `go test ./internal/config/...` — 13 tests pass (4 new ones cover the secret-validation paths)
- [x] `go vet ./...` — clean
- [x] `podman compose -f install/docker-compose.yml config` fails with a helpful error when `STROMBOLI_JWT_SECRET` is unset
- [x] `STROMBOLI_JWT_SECRET=$(openssl rand -base64 32) podman compose ... config` succeeds and shows `AUTH_ENABLED: true`
- [x] `make gen-jwt-secret` writes `install/.env` and refuses to overwrite on rerun
- [ ] Manual smoke: `docker compose up -d` against the new template, verify health + verify a request without `Authorization:` is rejected with 401

## Notes for review
- The placeholder list (`change-me`, `test-secret`, `generate-with-openssl-rand-base64-32`, …) is conservative — anyone with a non-pathological 32+ char secret passes.
- Existing `auth_test.go` uses `"test-jwt-secret"` directly with `auth.Config{}` and bypasses `Validate()`, so it is unaffected.
- ⚠️ CI (#63) currently shows a pre-existing tracing failure (OTel semconv schema URL mismatch from a recent dependabot bump). Filed as a separate follow-up — not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)