### PR TITLE
fix: emit logs as JSON by default for log aggregators (#47)

### DIFF
--- a/cmd/stromboli/main.go
+++ b/cmd/stromboli/main.go
@@ -49,10 +49,18 @@ const defaultHealthTimeout = 5 * time.Second
 
 
 func main() {
-	// Setup structured logging
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	}))
+	// Setup structured logging.
+	// JSON is the default so logs slot straight into Loki/CloudWatch/Datadog
+	// without fragile regex parsers. Operators can opt back into the human-
+	// readable text format with STROMBOLI_LOG_FORMAT=text (useful for local dev).
+	handlerOpts := &slog.HandlerOptions{Level: slog.LevelInfo}
+	var handler slog.Handler
+	if os.Getenv("STROMBOLI_LOG_FORMAT") == "text" {
+		handler = slog.NewTextHandler(os.Stdout, handlerOpts)
+	} else {
+		handler = slog.NewJSONHandler(os.Stdout, handlerOpts)
+	}
+	logger := slog.New(handler)
 	slog.SetDefault(logger)
 
 	slog.Info("Starting Stromboli 🌋", "version", version.String())

--- a/install/README.md
+++ b/install/README.md
@@ -59,6 +59,7 @@ Edit `stromboli.example.yaml` or use environment variables:
 | `STROMBOLI_AUTH_ENABLED` | `true` | Auth on by default. Set `false` only for local dev. |
 | `STROMBOLI_JWT_SECRET` | _(required when auth on)_ | Min 32 chars; generate with `openssl rand -base64 32`. |
 | `STROMBOLI_RATE_LIMIT_ENABLED` | `true` | Rate limiting on by default. |
+| `STROMBOLI_LOG_FORMAT` | `json` | `json` for log aggregators, `text` for local dev. |
 
 ## API Usage
 


### PR DESCRIPTION
## Summary
- Switched the default slog handler from `NewTextHandler` to `NewJSONHandler` in `cmd/stromboli/main.go`
- Added a `STROMBOLI_LOG_FORMAT=text` opt-out for local dev (read directly from env to keep logging working through `config.Load()` failures)
- Documented the new env var in `install/README.md`
- Closes #47

## Verification
Smoke test on a fresh build, default mode emits JSON:
\`\`\`
{"time":"2026-04-30T17:11:47Z","level":"INFO","msg":"Starting Stromboli 🌋","version":"dev"}
{"time":"2026-04-30T17:11:47Z","level":"INFO","msg":"Configuration loaded","server_address":":8080",...}
\`\`\`
With `STROMBOLI_LOG_FORMAT=text` the old format is preserved:
\`\`\`
time=2026-04-30T17:11:48Z level=INFO msg="Starting Stromboli 🌋" version=dev
\`\`\`

## Test plan
- [x] `go vet ./...` clean
- [x] Default startup emits JSON
- [x] `STROMBOLI_LOG_FORMAT=text` falls back to text
- [ ] Confirm Loki/CloudWatch/whatever the operator uses now ingests fields directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)