### PR TITLE
fix: serve /metrics on a separate listener bound to localhost (#46)

### DIFF
--- a/cmd/stromboli/main.go
+++ b/cmd/stromboli/main.go
@@ -32,6 +32,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"stromboli/internal/api"
 	"stromboli/internal/auth"
 	"stromboli/internal/claude"
@@ -301,8 +302,9 @@ func main() {
 	server := api.NewServer(podmanRunner, claudeClient, authConfig, rateLimitConfig, jobMgr, healthChecker, blacklist, cfg.Tracing.Enabled, cfg.Agent.SessionsDir, secretsRegistry, imagesRegistry)
 
 	srv := &http.Server{
-		Addr:    cfg.Server.Address,
-		Handler: server.Handler(),
+		Addr:              cfg.Server.Address,
+		Handler:           server.Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	// Start server in a goroutine
@@ -313,6 +315,30 @@ func main() {
 			os.Exit(1)
 		}
 	}()
+
+	// Start the metrics endpoint on a separate listener. The default address
+	// (127.0.0.1:9090) keeps Prometheus scrape data off any public interface;
+	// operators that need to expose it move it onto an internal-only network
+	// via STROMBOLI_METRICS_ADDRESS.
+	var metricsSrv *http.Server
+	if cfg.Metrics.Enabled {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
+		metricsSrv = &http.Server{
+			Addr:              cfg.Metrics.Address,
+			Handler:           mux,
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+		go func() {
+			slog.Info("Metrics endpoint starting", "addr", cfg.Metrics.Address)
+			if err := metricsSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				slog.Error("Metrics endpoint error", "error", err)
+				// Non-fatal: app keeps serving requests even if metrics listener fails.
+			}
+		}()
+	} else {
+		slog.Info("Metrics endpoint disabled")
+	}
 
 	// Wait for shutdown signal
 	<-ctx.Done()
@@ -344,6 +370,12 @@ func main() {
 
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		slog.Error("Server forced to shutdown", "error", err)
+	}
+
+	if metricsSrv != nil {
+		if err := metricsSrv.Shutdown(shutdownCtx); err != nil {
+			slog.Error("Metrics endpoint forced to shutdown", "error", err)
+		}
 	}
 
 	slog.Info("Server stopped")

--- a/install/README.md
+++ b/install/README.md
@@ -59,6 +59,7 @@ Edit `stromboli.example.yaml` or use environment variables:
 | `STROMBOLI_AUTH_ENABLED` | `true` | Auth on by default. Set `false` only for local dev. |
 | `STROMBOLI_JWT_SECRET` | _(required when auth on)_ | Min 32 chars; generate with `openssl rand -base64 32`. |
 | `STROMBOLI_RATE_LIMIT_ENABLED` | `true` | Rate limiting on by default. |
+| `STROMBOLI_METRICS_ADDRESS` | `127.0.0.1:9090` | Separate listener for `/metrics` — bind privately. |
 
 ## API Usage
 

--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -107,6 +107,18 @@ services:
       STROMBOLI_RATE_LIMIT_BURST: "20"
 
       # -------------------------------------------------------------------------
+      # Metrics
+      # -------------------------------------------------------------------------
+      # /metrics is served on a SEPARATE listener (default 127.0.0.1:9090).
+      # It exposes operational data (job counts, container lifecycle, request
+      # rates) that should not be public. Run Prometheus as a sidecar that
+      # reaches stromboli on the compose network, or set the bind address to
+      # a private interface. ":9090" (no host) exposes it on every interface —
+      # only do that behind a real network ACL.
+      STROMBOLI_METRICS_ENABLED: "true"
+      STROMBOLI_METRICS_ADDRESS: "127.0.0.1:9090"
+
+      # -------------------------------------------------------------------------
       # Job Cleanup
       # -------------------------------------------------------------------------
       STROMBOLI_JOBS_CLEANUP_TTL: "1h"

--- a/install/stromboli.example.yaml
+++ b/install/stromboli.example.yaml
@@ -172,6 +172,20 @@ jobs:
   cleanup_interval: "5m"
 
 # -----------------------------------------------------------------------------
+# Prometheus /metrics endpoint
+# -----------------------------------------------------------------------------
+# Served on a separate listener so it doesn't share the public port. Defaults
+# to 127.0.0.1:9090; set address to a private interface (or run Prometheus as
+# a sidecar) before exposing it more broadly. Setting address to ":9090"
+# binds on every interface — only do that behind a real network ACL.
+metrics:
+  # Env: STROMBOLI_METRICS_ENABLED
+  enabled: true
+
+  # Env: STROMBOLI_METRICS_ADDRESS
+  address: "127.0.0.1:9090"
+
+# -----------------------------------------------------------------------------
 # OpenTelemetry Tracing (Optional)
 # -----------------------------------------------------------------------------
 tracing:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 	"stromboli/internal/auth"
 	"stromboli/internal/claude"
@@ -84,9 +83,9 @@ func (s *Server) Handler() http.Handler {
 
 // setupRoutes configures all API routes
 func (s *Server) setupRoutes() {
-	// Health check and metrics are public (no auth required, no rate limiting)
+	// Health check is public (no auth required, no rate limiting).
+	// /metrics is served on a separate listener — see cmd/stromboli/main.go.
 	s.router.GET("/health", s.healthCheck)
-	s.router.GET("/metrics", gin.WrapH(promhttp.Handler()))
 
 	// Auth routes (JWT token generation, refresh, validation)
 	s.setupAuthRoutes()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Jobs      JobsConfig
 	Tracing   TracingConfig
 	Compose   ComposeConfig
+	Metrics   MetricsConfig
 }
 
 // ServerConfig holds HTTP server configuration
@@ -98,6 +99,17 @@ type TracingConfig struct {
 	Insecure    bool   // Use insecure connection (no TLS)
 }
 
+// MetricsConfig holds Prometheus metrics endpoint configuration.
+//
+// /metrics exposes operational data (job counts, container lifecycle, request
+// rates) and is served on a separate listener that defaults to localhost only.
+// Production scrapers should run alongside Stromboli (sidecar / DaemonSet) or
+// reach it through a private network — never put this on a public interface.
+type MetricsConfig struct {
+	Enabled bool   // Whether to expose /metrics (default: true)
+	Address string // Listener address (default: "127.0.0.1:9090")
+}
+
 // ComposeConfig holds compose environment configuration
 type ComposeConfig struct {
 	AllowPrivileged  bool          // Allow services with privileged: true (default: false)
@@ -129,6 +141,7 @@ const (
 	defaultTokenCacheTTL     = 5 * time.Minute
 	defaultTracingEndpoint   = "localhost:4317"
 	defaultTracingService    = "stromboli"
+	defaultMetricsAddress    = "127.0.0.1:9090"
 
 	// MinJWTSecretLength is the minimum allowed JWT secret length in bytes.
 	// 32 bytes matches the output of `openssl rand -base64 24` (32 chars) and
@@ -228,6 +241,12 @@ func setupViper(v *viper.Viper) {
 	v.SetDefault("compose.health_timeout", defaultComposeHealthTimeout.String())
 	v.SetDefault("compose.stack_ttl", defaultComposeStackTTL.String())
 
+	// Metrics endpoint defaults — bind to localhost so /metrics doesn't leak
+	// without an explicit operator opt-in. Set metrics.address to ":9090" to
+	// expose on all interfaces.
+	v.SetDefault("metrics.enabled", true)
+	v.SetDefault("metrics.address", defaultMetricsAddress)
+
 	// Environment variable configuration
 	v.SetEnvPrefix("STROMBOLI")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
@@ -277,6 +296,10 @@ func setupViper(v *viper.Viper) {
 	_ = v.BindEnv("compose.build_timeout", "STROMBOLI_COMPOSE_BUILD_TIMEOUT")
 	_ = v.BindEnv("compose.health_timeout", "STROMBOLI_COMPOSE_HEALTH_TIMEOUT")
 	_ = v.BindEnv("compose.stack_ttl", "STROMBOLI_COMPOSE_STACK_TTL")
+
+	// Metrics environment variables
+	_ = v.BindEnv("metrics.enabled", "STROMBOLI_METRICS_ENABLED")
+	_ = v.BindEnv("metrics.address", "STROMBOLI_METRICS_ADDRESS")
 }
 
 // parseConfig extracts and validates configuration from viper
@@ -386,6 +409,11 @@ func parseConfig(v *viper.Viper) (*Config, error) {
 		BuildTimeout:     composeBuildTimeout,
 		HealthTimeout:    composeHealthTimeout,
 		StackTTL:         composeStackTTL,
+	}
+
+	cfg.Metrics = MetricsConfig{
+		Enabled: v.GetBool("metrics.enabled"),
+		Address: v.GetString("metrics.address"),
 	}
 
 	// Validate configuration

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"stromboli/internal/api"
 	"stromboli/internal/auth"
 	"stromboli/internal/claude"
@@ -26,6 +27,7 @@ import (
 type testEnv struct {
 	Server      *api.Server
 	BaseURL     string
+	MetricsURL  string
 	ClaudeToken string
 	TempDir     string
 	SessionsDir string
@@ -159,6 +161,24 @@ func setupE2EEnv(t *testing.T) *testEnv {
 		}
 	}()
 
+	// Start a separate metrics listener on its own ephemeral port — mirrors
+	// the production layout where /metrics lives off the public router.
+	metricsListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		os.RemoveAll(tempDir)
+		t.Fatalf("failed to allocate metrics port: %v", err)
+	}
+	metricsAddr := metricsListener.Addr().String()
+	metricsURL := fmt.Sprintf("http://%s", metricsAddr)
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("/metrics", promhttp.Handler())
+	metricsSrv := &http.Server{Handler: metricsMux}
+	go func() {
+		if err := metricsSrv.Serve(metricsListener); err != nil && err != http.ErrServerClosed {
+			slog.Error("metrics server error", "error", err)
+		}
+	}()
+
 	// Wait for server to be ready
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -192,6 +212,7 @@ serverReady:
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		srv.Shutdown(ctx)
+		metricsSrv.Shutdown(ctx)
 		jobManager.StopCleanup()
 		os.RemoveAll(tempDir)
 	}
@@ -199,6 +220,7 @@ serverReady:
 	env := &testEnv{
 		Server:      server,
 		BaseURL:     baseURL,
+		MetricsURL:  metricsURL,
 		ClaudeToken: claudeToken,
 		TempDir:     tempDir,
 		SessionsDir: sessionsDir,

--- a/tests/e2e/health_test.go
+++ b/tests/e2e/health_test.go
@@ -25,14 +25,21 @@ func TestHealthEndpoint(t *testing.T) {
 		assert.NotEmpty(t, health["timestamp"])
 	})
 
-	t.Run("metrics endpoint returns 200", func(t *testing.T) {
-		resp := makeRequest(t, "GET", env.BaseURL+"/metrics", nil, nil)
+	t.Run("metrics endpoint returns 200 on the dedicated listener", func(t *testing.T) {
+		resp := makeRequest(t, "GET", env.MetricsURL+"/metrics", nil, nil)
 		defer resp.Body.Close()
 
 		assertStatusCode(t, resp, http.StatusOK)
 
 		body := readStringResponse(t, resp)
 		assert.Contains(t, body, "# HELP")
+	})
+
+	t.Run("metrics endpoint is not exposed on the public router", func(t *testing.T) {
+		// /metrics moved off the public listener to avoid leaking ops data.
+		resp := makeRequest(t, "GET", env.BaseURL+"/metrics", nil, nil)
+		defer resp.Body.Close()
+		assertStatusCode(t, resp, http.StatusNotFound)
 	})
 }
 


### PR DESCRIPTION
## Summary
- The Prometheus `/metrics` endpoint was registered on the public Gin router with no auth middleware — even with `STROMBOLI_AUTH_ENABLED=true`, an unauthenticated caller could read job counts, container lifecycle, and request rates.
- This PR splits `/metrics` off onto its own `http.Server` listener that **defaults to `127.0.0.1:9090`** (localhost only).
- Operators expose it more broadly only by deliberate choice — set `STROMBOLI_METRICS_ADDRESS` to a private interface or run Prometheus as a sidecar.
- Closes #46

## What changed
- **`cmd/stromboli/main.go`** — second `http.Server` with a plain `ServeMux` serving only `/metrics`; shut down on the same signal as the main server.
- **`internal/api/server.go`** — drop the `/metrics` route registration and `promhttp` import.
- **`internal/config/config.go`** — new `MetricsConfig{Enabled, Address}` with viper defaults + env bindings.
- **`tests/e2e`** — `testEnv` gains `MetricsURL` from a separate ephemeral listener; metrics test now hits that, plus a new test asserts `/metrics` returns 404 on the public port.
- **`install/docker-compose.yml`, `install/stromboli.example.yaml`, `install/README.md`** — updated.

## Behavior change
**Existing scrapers hitting `:8080/metrics` will get 404 after this lands.** They need to point at `127.0.0.1:9090/metrics` (or wherever the operator sets `STROMBOLI_METRICS_ADDRESS`).

## Test plan
- [x] `go vet ./...` clean
- [x] `go test -race ./internal/config/... ./internal/api/...` green
- [x] Binary builds
- [ ] e2e test (`-tags=e2e`, requires podman) verifies metrics on dedicated port + 404 on main
- [ ] Manual smoke: `curl :8080/metrics` → 404, `curl :9090/metrics` → Prometheus output

🤖 Generated with [Claude Code](https://claude.com/claude-code)