### PR TITLE
fix: make log level configurable via STROMBOLI_LOG_LEVEL (#48)

### DIFF
--- a/cmd/stromboli/main.go
+++ b/cmd/stromboli/main.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -48,13 +49,33 @@ import (
 // defaultHealthTimeout is the timeout for each health check component
 const defaultHealthTimeout = 5 * time.Second
 
+// parseLogLevel maps a STROMBOLI_LOG_LEVEL value to a slog.Level. Unknown
+// values fall back to Info; the caller is expected to emit a warning so the
+// typo is visible in the log stream.
+func parseLogLevel(s string) (slog.Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "info":
+		return slog.LevelInfo, true
+	case "debug":
+		return slog.LevelDebug, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error":
+		return slog.LevelError, true
+	default:
+		return slog.LevelInfo, false
+	}
+}
 
 func main() {
 	// Setup structured logging.
 	// JSON is the default so logs slot straight into Loki/CloudWatch/Datadog
 	// without fragile regex parsers. Operators can opt back into the human-
 	// readable text format with STROMBOLI_LOG_FORMAT=text (useful for local dev).
-	handlerOpts := &slog.HandlerOptions{Level: slog.LevelInfo}
+	// Log level is configurable via STROMBOLI_LOG_LEVEL (debug|info|warn|error).
+	rawLevel := os.Getenv("STROMBOLI_LOG_LEVEL")
+	logLevel, levelOK := parseLogLevel(rawLevel)
+	handlerOpts := &slog.HandlerOptions{Level: logLevel}
 	var handler slog.Handler
 	if os.Getenv("STROMBOLI_LOG_FORMAT") == "text" {
 		handler = slog.NewTextHandler(os.Stdout, handlerOpts)
@@ -63,6 +84,11 @@ func main() {
 	}
 	logger := slog.New(handler)
 	slog.SetDefault(logger)
+	if !levelOK {
+		slog.Warn("Unknown STROMBOLI_LOG_LEVEL — falling back to info",
+			"received", rawLevel,
+			"valid_values", "debug|info|warn|error")
+	}
 
 	slog.Info("Starting Stromboli 🌋", "version", version.String())
 

--- a/cmd/stromboli/main_test.go
+++ b/cmd/stromboli/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	cases := []struct {
+		in    string
+		want  slog.Level
+		ok    bool
+	}{
+		{"", slog.LevelInfo, true},
+		{"info", slog.LevelInfo, true},
+		{"INFO", slog.LevelInfo, true},
+		{"  Info  ", slog.LevelInfo, true},
+		{"debug", slog.LevelDebug, true},
+		{"warn", slog.LevelWarn, true},
+		{"warning", slog.LevelWarn, true},
+		{"error", slog.LevelError, true},
+		{"trace", slog.LevelInfo, false},
+		{"verbose", slog.LevelInfo, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, ok := parseLogLevel(tc.in)
+			if got != tc.want || ok != tc.ok {
+				t.Fatalf("parseLogLevel(%q) = (%v, %v), want (%v, %v)",
+					tc.in, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}

--- a/install/README.md
+++ b/install/README.md
@@ -60,6 +60,7 @@ Edit `stromboli.example.yaml` or use environment variables:
 | `STROMBOLI_JWT_SECRET` | _(required when auth on)_ | Min 32 chars; generate with `openssl rand -base64 32`. |
 | `STROMBOLI_RATE_LIMIT_ENABLED` | `true` | Rate limiting on by default. |
 | `STROMBOLI_LOG_FORMAT` | `json` | `json` for log aggregators, `text` for local dev. |
+| `STROMBOLI_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` — drop to `debug` for incidents. |
 | `STROMBOLI_METRICS_ADDRESS` | `127.0.0.1:9090` | Separate listener for `/metrics` — bind privately. |
 
 ## API Usage


### PR DESCRIPTION
## Summary
- `slog.LevelInfo` was hardcoded in `cmd/stromboli/main.go`. Operators couldn't enable debug logging during an incident without rebuilding.
- Adds `STROMBOLI_LOG_LEVEL` with values `debug` / `info` / `warn` / `error` (case-insensitive; `warning` also accepted; default `info`).
- Unknown values fall back to `info` but emit a startup `WARN` so the typo isn't silent.
- Closes #48

## Notes for review
- Pairs with `STROMBOLI_LOG_FORMAT` from #65 (#47) — same pattern, same env-var-only approach (no Viper coupling, so logging works through `config.Load()` failures).
- Audit suggested `slog.LevelVar` for runtime adjustment without restart. That's deferred — it needs a control surface (signal handler or admin endpoint) we don't have. Parse-at-startup covers the incident-response use case in 99% of deployments.
- New `parseLogLevel` helper has table-driven unit tests in `cmd/stromboli/main_test.go`.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test -race ./cmd/stromboli/...` green
- [x] Build succeeds
- [ ] Smoke: start with `STROMBOLI_LOG_LEVEL=debug` and confirm debug-level lines appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)