### PR TITLE
fix: use named volume for sessions in dev compose (#50)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,9 +303,8 @@ container-start:
 		echo "   Create it with: make secret-create"; \
 		echo ""; \
 	fi
-	@# Create sessions directory
-	@mkdir -p /tmp/stromboli-sessions
-	@# Start container
+	@# Sessions persist via the stromboli-sessions-dev named volume
+	@# (created automatically by `compose up`).
 	podman compose -f deployments/docker/compose.yml up -d
 	@echo ""
 	@echo "✅ Stromboli running:"

--- a/deployments/docker/compose.yml
+++ b/deployments/docker/compose.yml
@@ -1,4 +1,10 @@
-# Stromboli - Podman Compose Deployment
+# Stromboli - Podman Compose Deployment (DEV)
+#
+# ⚠️  This file is for local development. Do NOT use it for staging or
+#     anything resembling production:
+#       - Auth is off by default
+#       - Resource limits are minimal
+#     For production, see install/docker-compose.yml.
 #
 # Usage:
 #   cd /path/to/stromboli
@@ -40,8 +46,9 @@ services:
       # Mount Podman socket (rootless)
       - ${XDG_RUNTIME_DIR:-/run/user/1000}/podman/podman.sock:/run/podman/podman.sock:ro
 
-      # Sessions directory - use absolute path on host, same path in container
-      - /tmp/stromboli-sessions:/tmp/stromboli-sessions
+      # Sessions directory — named volume so dev state survives container
+      # restarts (the previous /tmp bind got wiped on every host reboot).
+      - stromboli-sessions-dev:/app/sessions
 
     # Claude credentials via Podman secret (secure, encrypted storage)
     secrets:
@@ -54,7 +61,7 @@ services:
       STROMBOLI_AGENT_IMAGE: "stromboli-agent"
       STROMBOLI_AGENT_IMAGE_TAG: "latest"
       STROMBOLI_AGENT_CREDENTIALS_FILE: "/home/user/.claude/.credentials.json"
-      STROMBOLI_AGENT_SESSIONS_DIR: "/tmp/stromboli-sessions"
+      STROMBOLI_AGENT_SESSIONS_DIR: "/app/sessions"
       CONTAINER_HOST: "unix:///run/podman/podman.sock"
 
       # Resource defaults
@@ -100,6 +107,15 @@ services:
       timeout: 5s
       retries: 3
       start_period: 5s
+
+# ==========================================================================
+# Volumes
+# ==========================================================================
+volumes:
+  # Named volume for session persistence in dev. Survives `compose down/up`
+  # and host reboots; remove with `podman volume rm stromboli-sessions-dev`.
+  stromboli-sessions-dev:
+    driver: local
 
 # ==========================================================================
 # Secrets - Compose-managed secrets (file-based)


### PR DESCRIPTION
## Summary
- \`deployments/docker/compose.yml\` mounted \`/tmp/stromboli-sessions\` both ways. /tmp is tmpfs on most Linux distros — every session silently disappeared on reboot.
- Replace the bind with a named podman volume \`stromboli-sessions-dev\` mounted at \`/app/sessions\`, mirroring \`install/docker-compose.yml\`.
- Loud DEV-ONLY header warning so anyone copying this file understands the trade-offs (auth off, minimal limits) and is pointed to \`install/docker-compose.yml\` for production.
- Drop the now-redundant \`mkdir -p /tmp/stromboli-sessions\` from \`make container-start\` — compose creates the named volume itself.
- Closes #50

## Test plan
- [x] \`podman compose -f deployments/docker/compose.yml config\` validates clean
- [ ] \`make container-start\` succeeds and \`podman volume ls\` shows \`stromboli-sessions-dev\`
- [ ] Session file written via the API survives \`podman compose down && up -d\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)