### PR TITLE
fix: default tracing.insecure to false (TLS) (#49)

### DIFF
--- a/deployments/docker/compose.yml
+++ b/deployments/docker/compose.yml
@@ -69,6 +69,9 @@ services:
       STROMBOLI_TRACING_ENABLED: "${STROMBOLI_TRACING_ENABLED:-false}"
       STROMBOLI_TRACING_SERVICE_NAME: "${STROMBOLI_TRACING_SERVICE_NAME:-stromboli}"
       STROMBOLI_TRACING_ENDPOINT: "${STROMBOLI_TRACING_ENDPOINT:-localhost:4317}"
+      # Dev compose talks to a local OTLP collector by default, so plaintext
+      # is acceptable here. Production (install/docker-compose.yml) defaults
+      # to TLS — set this to "true" only on localhost or trusted private nets.
       STROMBOLI_TRACING_INSECURE: "${STROMBOLI_TRACING_INSECURE:-true}"
 
     healthcheck:

--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -127,10 +127,13 @@ services:
       # -------------------------------------------------------------------------
       # Tracing (optional)
       # -------------------------------------------------------------------------
+      # Defaults to TLS. Set STROMBOLI_TRACING_INSECURE=true ONLY if the
+      # collector is on localhost or a trusted private network — plaintext
+      # OTLP leaks request metadata, session IDs, and internal routing.
       # STROMBOLI_TRACING_ENABLED: "true"
       # STROMBOLI_TRACING_SERVICE_NAME: "stromboli"
       # STROMBOLI_TRACING_ENDPOINT: "jaeger:4317"
-      # STROMBOLI_TRACING_INSECURE: "true"
+      # STROMBOLI_TRACING_INSECURE: "false"
 
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]

--- a/install/stromboli.example.yaml
+++ b/install/stromboli.example.yaml
@@ -201,10 +201,12 @@ tracing:
   # Env: STROMBOLI_TRACING_ENDPOINT
   endpoint: "localhost:4317"
 
-  # Use insecure connection (no TLS)
-  # Set to false in production with proper TLS
+  # Use insecure (plaintext) connection — disables TLS to the OTLP collector.
+  # Defaults to false. Set to true ONLY if the collector is on localhost or a
+  # trusted private network — plaintext OTLP leaks request metadata, session
+  # IDs, and internal routing details.
   # Env: STROMBOLI_TRACING_INSECURE
-  insecure: true
+  insecure: false
 
 # -----------------------------------------------------------------------------
 # Compose Environment Configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -231,7 +231,10 @@ func setupViper(v *viper.Viper) {
 	v.SetDefault("tracing.enabled", false)
 	v.SetDefault("tracing.service_name", defaultTracingService)
 	v.SetDefault("tracing.endpoint", defaultTracingEndpoint)
-	v.SetDefault("tracing.insecure", true)
+	// Tracing transport is TLS by default — plaintext gRPC leaks request
+	// metadata and session IDs. Operators with a localhost OTLP collector
+	// or trusted private network can opt back in via STROMBOLI_TRACING_INSECURE=true.
+	v.SetDefault("tracing.insecure", false)
 
 	// Compose defaults (secure by default)
 	v.SetDefault("compose.allow_privileged", false)


### PR DESCRIPTION
## Summary
- \`STROMBOLI_TRACING_INSECURE=true\` was the binary default and the documented default in both \`install/docker-compose.yml\` and \`stromboli.example.yaml\`. Operators turning tracing on without reading every comment shipped OTLP traces in plaintext gRPC — leaking request metadata, session IDs, and internal routing.
- This PR flips the default everywhere production-facing to \`false\` (TLS). Operators with a localhost collector or trusted private network can opt in to plaintext explicitly.
- Closes #49

## Behavior change
**Existing deployments that have tracing on without an explicit \`STROMBOLI_TRACING_INSECURE\` setting will start failing to connect to a non-TLS collector.** The fix is one of:
- Add TLS to the collector (recommended), or
- Set \`STROMBOLI_TRACING_INSECURE=true\` explicitly (acknowledging the leak)

The dev compose (\`deployments/docker/compose.yml\`) keeps \`true\` as the env-var default with a comment — local dev usually talks to a local Jaeger.

## What changed
- \`internal/config/config.go\` — \`v.SetDefault("tracing.insecure", false)\`
- \`install/stromboli.example.yaml\` — \`insecure: false\` + warning
- \`install/docker-compose.yml\` — example string flipped + warning comment
- \`deployments/docker/compose.yml\` — kept \`true\` for local dev with explicit comment

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/config/...\` green (no test assertions on insecure flag)
- [ ] Smoke: \`STROMBOLI_TRACING_ENABLED=true STROMBOLI_TRACING_ENDPOINT=plaintext-collector:4317\` fails to connect (proves default flipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)