### PR TITLE
chore: infra polish bundle — k8s manifests, prom rules, dev image notes (#53, #54, #55)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Linker flags to inject version
 LDFLAGS=-ldflags "-X stromboli/internal/version.Version=$(VERSION) -X stromboli/internal/version.Commit=$(COMMIT) -X stromboli/internal/version.BuildTime=$(BUILD_TIME)"
 
-# Go container command - uses --userns=keep-id to preserve host file ownership
+# Go container command - uses --userns=keep-id to preserve host file ownership.
+# This image is for dev / CI only (it ships the full Go toolchain). Production
+# images come from deployments/docker/Dockerfile.server, a minimal multi-stage
+# build — never tag or push GO_IMAGE as a deployment artifact.
 GO_IMAGE=golang:1.26
 GO_RUN=podman run --rm --userns=keep-id -v $(PWD):/app -w /app $(GO_IMAGE)
 

--- a/deployments/docker/Dockerfile.dev
+++ b/deployments/docker/Dockerfile.dev
@@ -1,4 +1,15 @@
 # Stromboli Development Image
+# =============================================================================
+# DEV / CI ONLY — NOT A DEPLOYMENT ARTIFACT.
+#
+# This image bundles the full Go toolchain plus podman so contributors can run
+# `go build`, `go test`, and integration tests without installing anything on
+# the host. Do not tag, push, or run this image in production: it is several
+# hundred MB and ships compiler + stdlib sources that the runtime doesn't need.
+#
+# Production builds use deployments/docker/Dockerfile.server, which is a
+# multi-stage build that copies only the compiled binary into a minimal image.
+# =============================================================================
 # Go + Podman for testing
 
 FROM docker.io/golang:1.26

--- a/deployments/grafana/README.md
+++ b/deployments/grafana/README.md
@@ -14,15 +14,28 @@ In Grafana:
 
 ### 2. Configure Prometheus
 
-Add Stromboli as a scrape target in `prometheus.yml`:
+Add Stromboli as a scrape target in `prometheus.yml`. Note that `/metrics`
+is served on a separate listener (default `127.0.0.1:9090`) — point the
+scraper there, not at the API port:
 
 ```yaml
 scrape_configs:
   - job_name: 'stromboli'
     static_configs:
-      - targets: ['localhost:8080']
+      - targets: ['localhost:9090']
     metrics_path: '/metrics'
+
+rule_files:
+  - 'prometheus-rules.yaml'
 ```
+
+### 3. Load alerting rules
+
+`prometheus-rules.yaml` ships alongside the dashboard with starter alerts
+for API error rate, latency, memory pressure, goroutine leaks, and stuck
+container cleanup. Tune the thresholds to your workload before paging
+on them. For kube-prometheus-stack users, wrap the `groups:` block in a
+`PrometheusRule` CR.
 
 ## Dashboard Panels
 

--- a/deployments/grafana/prometheus-rules.yaml
+++ b/deployments/grafana/prometheus-rules.yaml
@@ -1,0 +1,138 @@
+# =============================================================================
+# Prometheus alerting rules for Stromboli
+# =============================================================================
+#
+# Apply by either:
+#   - Loading directly into Prometheus: rule_files: [ "/etc/prometheus/rules/stromboli.yaml" ]
+#   - Wrapping in a Kubernetes PrometheusRule CR (for kube-prometheus-stack):
+#       apiVersion: monitoring.coreos.com/v1
+#       kind: PrometheusRule
+#       spec: { groups: <contents below> }
+#
+# Tuning:
+#   - All thresholds are starting points. Watch the dashboard for a week before
+#     paging on them — every Stromboli deployment has a different request mix.
+#   - Severity convention: `critical` pages on-call, `warning` opens a ticket.
+# =============================================================================
+groups:
+  - name: stromboli.api
+    interval: 30s
+    rules:
+      - alert: StrombiliAPIErrorRateHigh
+        expr: |
+          (
+            sum(rate(http_requests_total{status=~"5.."}[5m]))
+            /
+            sum(rate(http_requests_total[5m]))
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+          component: api
+        annotations:
+          summary: "Stromboli API 5xx rate above 5% (5m)"
+          description: |
+            More than 5% of HTTP requests have returned a 5xx response over
+            the last 5 minutes. Check `/health`, recent deploys, and the
+            container backend (Podman socket).
+
+      - alert: StrombiliAPILatencyHigh
+        expr: |
+          histogram_quantile(0.99,
+            sum(rate(http_request_duration_seconds_bucket[5m])) by (le, path)
+          ) > 5
+        for: 10m
+        labels:
+          severity: warning
+          component: api
+        annotations:
+          summary: "Stromboli p99 request latency > 5s (10m)"
+          description: |
+            p99 latency on at least one endpoint has been above 5s for 10
+            minutes. Likely culprits: slow agent containers, Claude API
+            stalls, or a backed-up job queue. Check job status with
+            `GET /jobs?status=running`.
+
+      - alert: StrombiliAPIDown
+        # /health is on the public listener and returns 200 on success. If
+        # the up{} target reports down OR no requests are coming through,
+        # something is wrong.
+        expr: up{job=~"stromboli.*"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          component: api
+        annotations:
+          summary: "Stromboli is unreachable from Prometheus"
+          description: |
+            Prometheus has not been able to scrape Stromboli for 2 minutes.
+            Pod crashed, network partitioned, or metrics endpoint moved.
+
+  - name: stromboli.runtime
+    interval: 30s
+    rules:
+      - alert: StrombiliMemoryHigh
+        # process_resident_memory_bytes is exposed automatically by
+        # promhttp. The threshold below assumes the operator-configured
+        # container memory limit is roughly 1Gi — adjust for your deploy.
+        expr: process_resident_memory_bytes > 0.8 * 1024 * 1024 * 1024
+        for: 10m
+        labels:
+          severity: warning
+          component: runtime
+        annotations:
+          summary: "Stromboli RSS > 80% of configured memory limit (10m)"
+          description: |
+            Memory pressure has been sustained for 10 minutes. Either the
+            agent container fleet has grown unexpectedly, sessions are
+            leaking, or the configured limit is too low for the workload.
+
+      - alert: StrombiliGoroutineLeak
+        # Goroutine count creeping up over time usually points at a leaked
+        # ticker, an unbounded channel, or a webhook handler that never
+        # returns. 5000 is conservative; tune it down once you have a
+        # baseline.
+        expr: go_goroutines > 5000
+        for: 15m
+        labels:
+          severity: warning
+          component: runtime
+        annotations:
+          summary: "Stromboli goroutine count > 5000 (15m)"
+          description: |
+            Goroutine count has stayed above 5000 for 15 minutes. Capture
+            a goroutine profile (pprof) and look for blocked workers.
+
+  - name: stromboli.containers
+    interval: 30s
+    rules:
+      - alert: StrombiliActiveContainersStuck
+        # active_containers should oscillate. A high, flat plateau often
+        # means agents aren't being cleaned up (orphaned pods, broken
+        # cleanup goroutine, podman socket wedged).
+        expr: stddev_over_time(active_containers[15m]) < 0.5 and active_containers > 5
+        for: 15m
+        labels:
+          severity: warning
+          component: containers
+        annotations:
+          summary: "Stromboli active container count flat-lined (15m)"
+          description: |
+            active_containers has been steady (>5, no variation) for 15
+            minutes. Likely the cleanup loop is stuck or agents aren't
+            being reaped. Check the container backend and recent logs
+            for "Failed to cleanup orphaned containers".
+
+      - alert: StrombiliActiveContainersSurge
+        expr: active_containers > 50
+        for: 5m
+        labels:
+          severity: critical
+          component: containers
+        annotations:
+          summary: "Stromboli active container count above 50 (5m)"
+          description: |
+            More than 50 agent containers running concurrently for 5
+            minutes. This is well above typical traffic for a single
+            instance — investigate before resource exhaustion takes the
+            whole node down.

--- a/deployments/kubernetes/README.md
+++ b/deployments/kubernetes/README.md
@@ -1,0 +1,59 @@
+# Stromboli on Kubernetes — reference manifests
+
+These manifests are a **reference architecture**, not a turnkey deployment. They show how the moving parts (ConfigMap, Secret, Deployment, two Services, PVC) fit together so teams can adapt them to their cluster's patterns (Helm chart, Argo, Flux, External Secrets, etc.).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `namespace.yaml` | The `stromboli` namespace. |
+| `configmap.yaml` | Non-secret config (matches `STROMBOLI_*` env vars elsewhere in the repo). |
+| `secret.example.yaml` | **Template** for the JWT secret + Claude credentials. Replace before applying. |
+| `deployment.yaml` | The Stromboli pod, ServiceAccount, and a PVC for session storage. |
+| `service.yaml` | One ClusterIP Service for HTTP (`:8080`), one for metrics (`:9090`). |
+| `kustomization.yaml` | Wires them together for `kubectl apply -k`. |
+
+## The Podman socket problem
+
+Stromboli spawns agents by talking to a **Podman socket** on the host. Kubernetes nodes don't run Podman by default, and Stromboli isn't a CRI client — it shells out to `podman` against `/run/podman/podman.sock`. That mismatch is the audit's "DaemonSet or privileged sidecar" caveat.
+
+Three patterns work; pick whichever your cluster supports:
+
+1. **Pinned-node hostPath** *(what these manifests assume)*: a subset of nodes runs Podman. Label them with `podman.io/socket=true`, install Podman + enable the user socket, and let the Deployment hostPath-mount `/run/podman/podman.sock`. Good for one-cluster-one-deployment setups; fragile if the labelled node goes away.
+
+2. **Privileged sidecar**: a sidecar container in the pod runs `podman system service` and exposes the socket on a shared `emptyDir`. Stromboli reaches it via `unix:///shared/podman.sock`. Heavier (privileged sidecar, double the resource footprint) but has no node coupling.
+
+3. **Off-K8s data plane**: run Stromboli on a VM or bare-metal host and only point K8s services at it. Often the cleanest path when you already manage Podman elsewhere.
+
+The provided manifests use pattern (1) for clarity. If you adopt (2) or (3), drop `nodeSelector.podman.io/socket` from `deployment.yaml` and either swap the `hostPath` for an `emptyDir` (pattern 2) or drop the volume entirely and point `CONTAINER_HOST` at the off-cluster socket (pattern 3).
+
+## Applying
+
+```bash
+# 1. Create your real secret. DO NOT commit the populated file.
+cp deployments/kubernetes/secret.example.yaml /tmp/stromboli-secret.yaml
+$EDITOR /tmp/stromboli-secret.yaml          # fill in JWT secret + Claude creds
+
+# 2. Apply the namespace + manifests.
+kubectl apply -f deployments/kubernetes/namespace.yaml
+kubectl apply -f /tmp/stromboli-secret.yaml
+kubectl apply -k deployments/kubernetes/    # configmap + deployment + services
+
+# 3. Verify.
+kubectl -n stromboli get pods,svc
+kubectl -n stromboli logs deploy/stromboli
+```
+
+For production, replace step 1 with whatever secret manager your platform team uses (External Secrets Operator + Vault/AWS-SM, sealed-secrets, ArgoCD vault plugin, etc.) and remove `secret.example.yaml` from `kustomization.yaml`.
+
+## Required cluster pieces
+
+- A **default StorageClass** (the PVC requests 10Gi, RWO).
+- An **Ingress** of your choice in front of the `stromboli` Service if external traffic is needed.
+- A **Prometheus** that respects the `prometheus.io/scrape` annotations on the `stromboli-metrics` Service (most kube-prometheus-stack installs do).
+
+## What's intentionally not here
+
+- No HorizontalPodAutoscaler — Stromboli holds in-memory job state; horizontal scaling needs the future external job store.
+- No NetworkPolicy — too cluster-specific. Add one that allows ingress to `:8080` from your ingress namespace and `:9090` from your monitoring namespace, plus egress to `kube-dns` and the OTLP collector.
+- No PodDisruptionBudget — with `replicas: 1` and `strategy: Recreate`, a PDB doesn't help. If you move to (2) above and bump replicas, add one.

--- a/deployments/kubernetes/configmap.yaml
+++ b/deployments/kubernetes/configmap.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stromboli-config
+  namespace: stromboli
+  labels:
+    app.kubernetes.io/name: stromboli
+data:
+  # ---------------------------------------------------------------------------
+  # Server
+  # ---------------------------------------------------------------------------
+  STROMBOLI_SERVER_ADDRESS: ":8080"
+  STROMBOLI_LOG_FORMAT: "json"
+  STROMBOLI_LOG_LEVEL: "info"
+
+  # ---------------------------------------------------------------------------
+  # Agent containers
+  # ---------------------------------------------------------------------------
+  STROMBOLI_AGENT_IMAGE: "ghcr.io/tomblancdev/stromboli-agent"
+  STROMBOLI_AGENT_IMAGE_TAG: "latest"
+  STROMBOLI_AGENT_MOUNT_CLAUDE_CLI: "true"
+  STROMBOLI_AGENT_CLI_IMAGE: "ghcr.io/tomblancdev/stromboli-agent"
+  STROMBOLI_AGENT_CLI_IMAGE_TAG: "latest"
+  STROMBOLI_AGENT_AUTO_PULL_CLI: "true"
+  STROMBOLI_AGENT_CREDENTIALS_FILE: "/home/stromboli/.claude/.credentials.json"
+  STROMBOLI_AGENT_SESSIONS_DIR: "/app/sessions"
+  STROMBOLI_TOKEN_CACHE_ENABLED: "true"
+  STROMBOLI_TOKEN_CACHE_TTL: "5m"
+
+  # ---------------------------------------------------------------------------
+  # Resource defaults (per agent container)
+  # ---------------------------------------------------------------------------
+  STROMBOLI_RESOURCES_MEMORY: "512m"
+  STROMBOLI_RESOURCES_CPUS: "1"
+  STROMBOLI_RESOURCES_TIMEOUT: "30m"
+
+  # ---------------------------------------------------------------------------
+  # Auth (secure-by-default; JWT secret comes from the Secret)
+  # ---------------------------------------------------------------------------
+  STROMBOLI_AUTH_ENABLED: "true"
+  STROMBOLI_JWT_EXPIRY: "24h"
+  STROMBOLI_JWT_REFRESH_EXPIRY: "168h"
+
+  # ---------------------------------------------------------------------------
+  # Rate limiting
+  # ---------------------------------------------------------------------------
+  STROMBOLI_RATE_LIMIT_ENABLED: "true"
+  STROMBOLI_RATE_LIMIT_RPS: "10"
+  STROMBOLI_RATE_LIMIT_BURST: "20"
+
+  # ---------------------------------------------------------------------------
+  # Metrics — bound to 0.0.0.0:9090 inside the pod, but the Service does not
+  # expose it externally. Reach it from a Prometheus scrape sidecar / pod, or
+  # add a separate ClusterIP Service if you need cross-namespace scraping.
+  # ---------------------------------------------------------------------------
+  STROMBOLI_METRICS_ENABLED: "true"
+  STROMBOLI_METRICS_ADDRESS: "0.0.0.0:9090"
+
+  # ---------------------------------------------------------------------------
+  # Job cleanup
+  # ---------------------------------------------------------------------------
+  STROMBOLI_JOBS_CLEANUP_TTL: "1h"
+  STROMBOLI_JOBS_CLEANUP_INTERVAL: "5m"

--- a/deployments/kubernetes/deployment.yaml
+++ b/deployments/kubernetes/deployment.yaml
@@ -1,0 +1,132 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stromboli
+  namespace: stromboli
+  labels:
+    app.kubernetes.io/name: stromboli
+    app.kubernetes.io/component: api
+spec:
+  # Stromboli holds in-memory job state and writes session files to a volume,
+  # so replicas > 1 needs a shared volume + sticky sessions or a future
+  # external job store. Keep at 1 unless you've designed for that.
+  replicas: 1
+  strategy:
+    # Recreate avoids two pods racing for the Podman socket when rolling.
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: stromboli
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: stromboli
+        app.kubernetes.io/component: api
+    spec:
+      serviceAccountName: stromboli
+      # Stromboli must be on a node that runs Podman and exposes its socket
+      # at /run/podman/podman.sock. The audit's recommendation is one of:
+      #   1. A DaemonSet of Stromboli pinned to nodes with podman installed
+      #      (requires hostPath mount + node-affinity to those nodes).
+      #   2. A privileged sidecar that runs Podman in the pod (not shown).
+      #   3. Use a managed kpodman / Kubevirt-on-Podman environment.
+      # The simplest reference is option 1, captured below: this Deployment
+      # uses a hostPath mount and assumes podman.io/socket=true on its nodes.
+      nodeSelector:
+        podman.io/socket: "true"
+      containers:
+        - name: stromboli
+          image: ghcr.io/tomblancdev/stromboli:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: stromboli-config
+          env:
+            - name: STROMBOLI_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: stromboli-secrets
+                  key: STROMBOLI_JWT_SECRET
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+            # Podman socket — see the nodeSelector + caveats above.
+            - name: podman-socket
+              mountPath: /run/podman/podman.sock
+            # Claude credentials are projected from the Secret as a single
+            # JSON file at the path Stromboli expects.
+            - name: claude-credentials
+              mountPath: /home/stromboli/.claude
+              readOnly: true
+            # Sessions persist between pod restarts via a PVC.
+            - name: sessions
+              mountPath: /app/sessions
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: podman-socket
+          hostPath:
+            path: /run/podman/podman.sock
+            type: Socket
+        - name: claude-credentials
+          secret:
+            secretName: stromboli-secrets
+            items:
+              - key: credentials.json
+                path: .credentials.json
+                mode: 0400
+        - name: sessions
+          persistentVolumeClaim:
+            claimName: stromboli-sessions
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stromboli
+  namespace: stromboli
+  labels:
+    app.kubernetes.io/name: stromboli
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: stromboli-sessions
+  namespace: stromboli
+  labels:
+    app.kubernetes.io/name: stromboli
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/deployments/kubernetes/kustomization.yaml
+++ b/deployments/kubernetes/kustomization.yaml
@@ -1,0 +1,21 @@
+# =============================================================================
+# Stromboli — Kubernetes reference manifests
+# =============================================================================
+#
+# Use as a starting point, not a turnkey deployment. Read deployments/
+# kubernetes/README.md for the Podman socket / DaemonSet caveats.
+#
+# Apply with:
+#   kubectl apply -k deployments/kubernetes/
+# =============================================================================
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: stromboli
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret.example.yaml   # replace with secret.yaml in your overlay
+  - deployment.yaml
+  - service.yaml

--- a/deployments/kubernetes/namespace.yaml
+++ b/deployments/kubernetes/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stromboli
+  labels:
+    app.kubernetes.io/name: stromboli
+    app.kubernetes.io/part-of: stromboli

--- a/deployments/kubernetes/secret.example.yaml
+++ b/deployments/kubernetes/secret.example.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Stromboli secrets — TEMPLATE
+# =============================================================================
+#
+# DO NOT commit a populated copy of this file. Either:
+#   1. Copy to secret.yaml, fill in values, apply, then `git rm` the copy, OR
+#   2. Use a real secret manager (External Secrets Operator, sealed-secrets,
+#      Vault Agent Injector, AWS/GCP Secret Manager CSI driver) and replace
+#      this file with the corresponding CR.
+#
+# Generate the JWT secret with: openssl rand -base64 32
+# =============================================================================
+apiVersion: v1
+kind: Secret
+metadata:
+  name: stromboli-secrets
+  namespace: stromboli
+  labels:
+    app.kubernetes.io/name: stromboli
+type: Opaque
+stringData:
+  # JWT signing secret. Min 32 chars; the server refuses to start if this is
+  # empty, too short, or a known placeholder.
+  STROMBOLI_JWT_SECRET: "REPLACE_ME_WITH_OPENSSL_RAND_BASE64_32"
+
+  # Claude credentials JSON (entire file contents). Mounted by the Deployment
+  # at /home/stromboli/.claude/.credentials.json — STROMBOLI_AGENT_CREDENTIALS_FILE
+  # in the ConfigMap points at this path.
+  credentials.json: |
+    {
+      "REPLACE_ME": "paste your ~/.claude/.credentials.json contents here"
+    }

--- a/deployments/kubernetes/service.yaml
+++ b/deployments/kubernetes/service.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stromboli
+  namespace: stromboli
+  labels:
+    app.kubernetes.io/name: stromboli
+    app.kubernetes.io/component: api
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: stromboli
+    app.kubernetes.io/component: api
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+---
+# Separate metrics Service so cluster-internal Prometheus can scrape /metrics
+# without going through the same path as user traffic. /metrics is *not*
+# exposed on the public Service above.
+apiVersion: v1
+kind: Service
+metadata:
+  name: stromboli-metrics
+  namespace: stromboli
+  labels:
+    app.kubernetes.io/name: stromboli
+    app.kubernetes.io/component: metrics
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9090"
+    prometheus.io/path: "/metrics"
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: stromboli
+    app.kubernetes.io/component: api
+  ports:
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+      protocol: TCP


### PR DESCRIPTION
## Summary
Bundles the three remaining low-severity audit items into one infra-polish PR.

## Changes

### #53 — Mark Dockerfile.dev / GO_IMAGE as dev-only
- \`deployments/docker/Dockerfile.dev\` gets a header making explicit it's dev/CI only and must never be tagged as a deployment artefact.
- Same warning on the \`GO_IMAGE\` Makefile variable.
- Production images already come from \`Dockerfile.server\` (multi-stage), so no code refactor needed — just clearer signposting per the audit's recommendation.

### #54 — Kubernetes reference manifests under \`deployments/kubernetes/\`
- Namespace, ConfigMap, Secret template, Deployment (+ ServiceAccount + PVC), HTTP + metrics Services, and a kustomization.yaml.
- README walks through the Podman-socket-on-K8s problem and lists the three viable patterns (pinned-node hostPath, privileged sidecar, off-K8s data plane). Manifests as shipped use the simplest one for clarity.
- Explicitly **not** turnkey — teams are expected to swap the example Secret for their secret manager (External Secrets, sealed-secrets, Vault) and add Ingress / NetworkPolicy / PDB to fit their cluster.

### #55 — Prometheus alerting rules
- \`deployments/grafana/prometheus-rules.yaml\` with starter alerts:
  - **critical**: API 5xx > 5% (5m), scrape down, container surge > 50
  - **warning**: p99 latency > 5s (10m), memory > 80% (10m), goroutine leak > 5000 (15m), stuck active-container count
- README updated to point at the rules file and the correct scrape target (\`:9090\`, not \`:8080\`, since #46).

## Test plan
- [x] All 7 new YAMLs parse with PyYAML
- [x] kustomization.yaml lists every manifest
- [ ] Apply manifests against a real cluster (kind or k3d) — out of scope for this PR
- [ ] Load \`prometheus-rules.yaml\` into a Prometheus instance and verify rules compile (requires a running scraper)

## Notes for review
- All thresholds in the alerting rules are explicit "tune for your workload" starting points. Better to start conservative and ratchet down once a baseline emerges.
- The Deployment uses \`replicas: 1\` + \`strategy: Recreate\` because Stromboli holds in-memory job state. README documents this and the path to horizontal scaling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)