### PR TITLE
feat: surface token usage and estimated cost on run responses (#56)

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1477,6 +1477,14 @@ const docTemplate = `{
                 "structured_output": {
                     "description": "Extracted structured_output from Claude's JSON envelope (when json_schema is used).\nConvenience field so callers don't need to parse the envelope themselves.",
                     "type": "object"
+                },
+                "usage": {
+                    "description": "Token usage totals + estimated USD cost. Populated best-effort from the\nsession's JSONL; nil when the session file isn't readable yet or no\nassistant message reported usage.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/stromboli_internal_job.Usage"
+                        }
+                    ]
                 }
             }
         },
@@ -1919,6 +1927,34 @@ const docTemplate = `{
                 "StatusCrashed",
                 "StatusCancelled"
             ]
+        },
+        "stromboli_internal_job.Usage": {
+            "type": "object",
+            "properties": {
+                "cache_creation_input_tokens": {
+                    "type": "integer"
+                },
+                "cache_read_input_tokens": {
+                    "type": "integer"
+                },
+                "estimated_cost_usd": {
+                    "description": "EstimatedCostUSD is best-effort: tokens × Anthropic's published\nper-1M rates, summed across all four buckets. Zero when the model\nisn't recognized or no usage was reported.",
+                    "type": "number"
+                },
+                "input_tokens": {
+                    "type": "integer"
+                },
+                "model": {
+                    "description": "Model identifier reported by Claude (e.g. \"claude-opus-4-7-20260101\").\nEmpty when the model is unknown — cost estimation skipped in that case.",
+                    "type": "string"
+                },
+                "output_tokens": {
+                    "type": "integer"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
         },
         "stromboli_internal_types.ClaudeOptions": {
             "description": "All available Claude CLI options for headless execution",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1471,6 +1471,14 @@
                 "structured_output": {
                     "description": "Extracted structured_output from Claude's JSON envelope (when json_schema is used).\nConvenience field so callers don't need to parse the envelope themselves.",
                     "type": "object"
+                },
+                "usage": {
+                    "description": "Token usage totals + estimated USD cost. Populated best-effort from the\nsession's JSONL; nil when the session file isn't readable yet or no\nassistant message reported usage.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/stromboli_internal_job.Usage"
+                        }
+                    ]
                 }
             }
         },
@@ -1913,6 +1921,34 @@
                 "StatusCrashed",
                 "StatusCancelled"
             ]
+        },
+        "stromboli_internal_job.Usage": {
+            "type": "object",
+            "properties": {
+                "cache_creation_input_tokens": {
+                    "type": "integer"
+                },
+                "cache_read_input_tokens": {
+                    "type": "integer"
+                },
+                "estimated_cost_usd": {
+                    "description": "EstimatedCostUSD is best-effort: tokens × Anthropic's published\nper-1M rates, summed across all four buckets. Zero when the model\nisn't recognized or no usage was reported.",
+                    "type": "number"
+                },
+                "input_tokens": {
+                    "type": "integer"
+                },
+                "model": {
+                    "description": "Model identifier reported by Claude (e.g. \"claude-opus-4-7-20260101\").\nEmpty when the model is unknown — cost estimation skipped in that case.",
+                    "type": "string"
+                },
+                "output_tokens": {
+                    "type": "integer"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
         },
         "stromboli_internal_types.ClaudeOptions": {
             "description": "All available Claude CLI options for headless execution",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -333,6 +333,13 @@ definitions:
           Extracted structured_output from Claude's JSON envelope (when json_schema is used).
           Convenience field so callers don't need to parse the envelope themselves.
         type: object
+      usage:
+        allOf:
+        - $ref: '#/definitions/stromboli_internal_job.Usage'
+        description: |-
+          Token usage totals + estimated USD cost. Populated best-effort from the
+          session's JSONL; nil when the session file isn't readable yet or no
+          assistant message reported usage.
     type: object
   internal_api.SearchResultResponse:
     description: Search result from a container registry
@@ -653,6 +660,30 @@ definitions:
     - StatusFailed
     - StatusCrashed
     - StatusCancelled
+  stromboli_internal_job.Usage:
+    properties:
+      cache_creation_input_tokens:
+        type: integer
+      cache_read_input_tokens:
+        type: integer
+      estimated_cost_usd:
+        description: |-
+          EstimatedCostUSD is best-effort: tokens × Anthropic's published
+          per-1M rates, summed across all four buckets. Zero when the model
+          isn't recognized or no usage was reported.
+        type: number
+      input_tokens:
+        type: integer
+      model:
+        description: |-
+          Model identifier reported by Claude (e.g. "claude-opus-4-7-20260101").
+          Empty when the model is unknown — cost estimation skipped in that case.
+        type: string
+      output_tokens:
+        type: integer
+      total_tokens:
+        type: integer
+    type: object
   stromboli_internal_types.ClaudeOptions:
     description: All available Claude CLI options for headless execution
     properties:

--- a/internal/api/async.go
+++ b/internal/api/async.go
@@ -113,6 +113,13 @@ func (s *Server) runAsync(c *gin.Context) {
 			s.jobMgr.Update(jobID, status, output, errMsg, sessionID)
 		}
 
+		// Best-effort attach token usage / cost. Skipped silently if the
+		// session has no JSONL yet or the runner failed before producing one.
+		usage := buildUsage(s.historyHandler.Reader(), sessionID)
+		if usage != nil {
+			s.jobMgr.SetUsage(jobID, usage)
+		}
+
 		// Send webhook notification if URL provided
 		if webhookURL != "" {
 			notifier := webhook.NewNotifier()
@@ -122,6 +129,7 @@ func (s *Server) runAsync(c *gin.Context) {
 				Output:    output,
 				Error:     errMsg,
 				SessionID: sessionID,
+				Usage:     usage,
 			}
 
 			// Send webhook in background, don't block on failure

--- a/internal/api/run.go
+++ b/internal/api/run.go
@@ -59,6 +59,10 @@ type RunResponse struct {
 	Error string `json:"error,omitempty" example:""`
 	// Session ID for conversation continuation
 	SessionID string `json:"session_id,omitempty" example:"sess-abc123def456"`
+	// Token usage totals + estimated USD cost. Populated best-effort from the
+	// session's JSONL; nil when the session file isn't readable yet or no
+	// assistant message reported usage.
+	Usage *job.Usage `json:"usage,omitempty"`
 	// Crash details (when status is "crashed")
 	CrashInfo *job.CrashInfo `json:"crash_info,omitempty"`
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -221,6 +221,7 @@ func (s *Server) runClaude(c *gin.Context) {
 		Output:           result.Output,
 		StructuredOutput: extractStructuredOutput(result.Output),
 		SessionID:        result.SessionID,
+		Usage:            buildUsage(s.historyHandler.Reader(), result.SessionID),
 		CrashInfo:        crashInfo,
 	})
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -665,3 +665,54 @@ type errorMockExecutor struct {
 func (m *errorMockExecutor) Run(ctx context.Context, args []string) ([]byte, error) {
 	return nil, m.err
 }
+
+func TestRun_PopulatesUsage(t *testing.T) {
+	tmpDir := t.TempDir()
+	secretsFile := filepath.Join(tmpDir, ".claude-secrets")
+	sessionsDir := filepath.Join(tmpDir, "sessions")
+	require.NoError(t, os.WriteFile(secretsFile, []byte("test-token"), 0600))
+
+	const sessionID = "sess-usage-1"
+	// Pre-write the session JSONL so the post-run aggregation has data to
+	// consume. The reader looks under <sessionsDir>/<sid>/.claude/projects/*/<sid>.jsonl.
+	jsonlDir := filepath.Join(sessionsDir, sessionID, ".claude", "projects", "-workspace")
+	require.NoError(t, os.MkdirAll(jsonlDir, 0755))
+	jsonl := `{"type":"user","uuid":"u1","sessionId":"` + sessionID + `","timestamp":"2026-01-24T10:00:00.000Z","message":{"role":"user","content":"hi"}}
+{"type":"assistant","uuid":"a1","sessionId":"` + sessionID + `","timestamp":"2026-01-24T10:00:01.000Z","message":{"role":"assistant","model":"claude-sonnet-4-6","id":"m1","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1000,"output_tokens":200,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(jsonlDir, sessionID+".jsonl"), []byte(jsonl), 0644))
+
+	mockRunner := &runner.MockRunner{
+		RunFunc: func(ctx context.Context, req runner.Request) (*runner.Result, error) {
+			return &runner.Result{ID: "run-x", Output: "hello", SessionID: sessionID}, nil
+		},
+	}
+	claudeClient := claude.NewClient(secretsFile)
+	jobMgr := job.NewManager()
+	server := NewServer(
+		mockRunner, claudeClient,
+		auth.Config{Enabled: false}, RateLimitConfig{Enabled: false},
+		jobMgr, nil, nil, false, sessionsDir,
+		secrets.NewRegistry(&mockTestExecutor{}),
+		images.NewRegistry(&mockTestExecutor{}),
+	)
+
+	body := bytes.NewBufferString(`{"prompt": "hi", "claude": {"session_id": "` + sessionID + `"}}`)
+	req, err := http.NewRequest(http.MethodPost, "/run", body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp RunResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Usage, "usage should be populated when session JSONL has data")
+	assert.Equal(t, "claude-sonnet-4-6", resp.Usage.Model)
+	assert.Equal(t, 1000, resp.Usage.InputTokens)
+	assert.Equal(t, 200, resp.Usage.OutputTokens)
+	assert.Equal(t, 1200, resp.Usage.TotalTokens)
+	// 1000 input @ $3/1M + 200 output @ $15/1M = 0.003 + 0.003 = 0.006
+	assert.InDelta(t, 0.006, resp.Usage.EstimatedCostUSD, 1e-9)
+}

--- a/internal/api/session_history.go
+++ b/internal/api/session_history.go
@@ -20,6 +20,12 @@ func NewSessionHistoryHandler(sessionsDir string) *SessionHistoryHandler {
 	}
 }
 
+// Reader returns the underlying history reader so other handlers (like /run)
+// can aggregate session data without re-creating the reader.
+func (h *SessionHistoryHandler) Reader() *history.Reader {
+	return h.reader
+}
+
 // SessionMessagesResponse is the response for listing session messages
 // @Description Paginated list of session messages
 type SessionMessagesResponse struct {

--- a/internal/api/usage.go
+++ b/internal/api/usage.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"log/slog"
+	"math"
+
+	"stromboli/internal/history"
+	"stromboli/internal/job"
+	"stromboli/internal/pricing"
+)
+
+// buildUsage aggregates the session's JSONL token totals and estimates cost.
+// Returns nil when the file is missing, no usage was reported, or aggregation
+// fails — token usage is a best-effort field on top of the run result, never
+// a fatal error.
+func buildUsage(reader *history.Reader, sessionID string) *job.Usage {
+	if reader == nil || sessionID == "" {
+		return nil
+	}
+	summary, err := reader.AggregateUsage(sessionID)
+	if err != nil {
+		slog.Debug("usage aggregation skipped", "session_id", sessionID, "error", err)
+		return nil
+	}
+	if summary == nil {
+		return nil
+	}
+
+	rates, _ := pricing.LookupRates(summary.Model)
+	cost := pricing.EstimateUSD(pricing.Tokens{
+		Input:         summary.InputTokens,
+		Output:        summary.OutputTokens,
+		CacheCreation: summary.CacheCreationInputTokens,
+		CacheRead:     summary.CacheReadInputTokens,
+	}, rates)
+
+	return &job.Usage{
+		Model:                    summary.Model,
+		InputTokens:              summary.InputTokens,
+		OutputTokens:             summary.OutputTokens,
+		CacheCreationInputTokens: summary.CacheCreationInputTokens,
+		CacheReadInputTokens:     summary.CacheReadInputTokens,
+		TotalTokens:              summary.TotalTokens,
+		// Round to 6 decimal places so JSON consumers don't see binary noise
+		// like 0.00777629999... for clean inputs.
+		EstimatedCostUSD: math.Round(cost*1e6) / 1e6,
+	}
+}

--- a/internal/history/reader.go
+++ b/internal/history/reader.go
@@ -212,7 +212,7 @@ func (r *Reader) AggregateUsage(sessionID string) (*UsageSummary, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open session file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	scanner := bufio.NewScanner(file)
 	buf := make([]byte, 0, 1024*1024)

--- a/internal/history/reader.go
+++ b/internal/history/reader.go
@@ -196,6 +196,66 @@ func (r *Reader) GetMessage(sessionID, messageUUID string) (*Message, error) {
 	return nil, fmt.Errorf("message not found: %s", messageUUID)
 }
 
+// AggregateUsage walks the session JSONL once and sums every assistant
+// message's `usage` block. Returns the totals plus the most recently seen
+// model identifier (used for cost estimation).
+//
+// Returns (nil, nil) if the session file exists but no assistant message has
+// usage info — that's a normal in-flight state, not an error.
+func (r *Reader) AggregateUsage(sessionID string) (*UsageSummary, error) {
+	filePath, err := r.findSessionFile(sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open session file: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 0, 1024*1024)
+	scanner.Buffer(buf, 10*1024*1024)
+
+	var summary UsageSummary
+	hasUsage := false
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		msg, err := r.parseMessage(line)
+		if err != nil {
+			continue
+		}
+		if msg.Type != MessageTypeAssistant || msg.Content.Usage == nil {
+			continue
+		}
+		u := msg.Content.Usage
+		summary.InputTokens += u.InputTokens
+		summary.OutputTokens += u.OutputTokens
+		summary.CacheCreationInputTokens += u.CacheCreationInputTokens
+		summary.CacheReadInputTokens += u.CacheReadInputTokens
+		if msg.Content.Model != "" {
+			summary.Model = msg.Content.Model
+		}
+		hasUsage = true
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading session file: %w", err)
+	}
+	if !hasUsage {
+		return nil, nil
+	}
+
+	summary.TotalTokens = summary.InputTokens + summary.OutputTokens +
+		summary.CacheCreationInputTokens + summary.CacheReadInputTokens
+	return &summary, nil
+}
+
 // parseMessage converts a raw JSONL line to a Message
 func (r *Reader) parseMessage(line []byte) (*Message, error) {
 	var raw rawMessage

--- a/internal/history/reader_test.go
+++ b/internal/history/reader_test.go
@@ -260,3 +260,59 @@ func TestReader_ListMessages_LimitEnforcement(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 50, result.Limit)
 }
+
+func TestReader_AggregateUsage_NoSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	reader := NewReader(tmpDir)
+
+	summary, err := reader.AggregateUsage("missing-session")
+	assert.Error(t, err)
+	assert.Nil(t, summary)
+}
+
+func TestReader_AggregateUsage_NoUsageReported(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionID := "test-no-usage"
+
+	sessionDir := filepath.Join(tmpDir, sessionID, ".claude", "projects", "-workspace")
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+
+	jsonlFile := filepath.Join(sessionDir, sessionID+".jsonl")
+	// User-only session: no assistant messages with usage.
+	data := `{"type":"user","uuid":"u1","sessionId":"test-no-usage","timestamp":"2026-01-24T10:00:00.000Z","message":{"role":"user","content":"hi"}}
+`
+	require.NoError(t, os.WriteFile(jsonlFile, []byte(data), 0644))
+
+	summary, err := NewReader(tmpDir).AggregateUsage(sessionID)
+	require.NoError(t, err)
+	assert.Nil(t, summary, "no assistant usage = nil summary, not an error")
+}
+
+func TestReader_AggregateUsage_SumsAcrossMessages(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionID := "test-aggregate"
+
+	sessionDir := filepath.Join(tmpDir, sessionID, ".claude", "projects", "-workspace")
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+
+	jsonlFile := filepath.Join(sessionDir, sessionID+".jsonl")
+	// Two assistant messages — the aggregator should sum every bucket and keep
+	// the most recent model name.
+	data := `{"type":"user","uuid":"u1","sessionId":"test-aggregate","timestamp":"2026-01-24T10:00:00.000Z","message":{"role":"user","content":"hi"}}
+{"type":"assistant","uuid":"a1","parentUuid":"u1","sessionId":"test-aggregate","timestamp":"2026-01-24T10:00:01.000Z","message":{"role":"assistant","model":"claude-sonnet-4-6","id":"m1","content":[{"type":"text","text":"first"}],"usage":{"input_tokens":100,"output_tokens":20,"cache_creation_input_tokens":50,"cache_read_input_tokens":200}}}
+{"type":"user","uuid":"u2","sessionId":"test-aggregate","timestamp":"2026-01-24T10:00:02.000Z","message":{"role":"user","content":"more"}}
+{"type":"assistant","uuid":"a2","parentUuid":"u2","sessionId":"test-aggregate","timestamp":"2026-01-24T10:00:03.000Z","message":{"role":"assistant","model":"claude-opus-4-7","id":"m2","content":[{"type":"text","text":"second"}],"usage":{"input_tokens":50,"output_tokens":80,"cache_creation_input_tokens":0,"cache_read_input_tokens":300}}}
+`
+	require.NoError(t, os.WriteFile(jsonlFile, []byte(data), 0644))
+
+	summary, err := NewReader(tmpDir).AggregateUsage(sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, 150, summary.InputTokens)
+	assert.Equal(t, 100, summary.OutputTokens)
+	assert.Equal(t, 50, summary.CacheCreationInputTokens)
+	assert.Equal(t, 500, summary.CacheReadInputTokens)
+	assert.Equal(t, 800, summary.TotalTokens)
+	// Latest model wins so cost lookup uses the most recent.
+	assert.Equal(t, "claude-opus-4-7", summary.Model)
+}

--- a/internal/history/types.go
+++ b/internal/history/types.go
@@ -98,6 +98,17 @@ type Usage struct {
 	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty" example:"18121"`
 }
 
+// UsageSummary is the aggregated token usage across every assistant message in
+// a session, plus the model identifier used for cost lookup.
+type UsageSummary struct {
+	Model                    string
+	InputTokens              int
+	OutputTokens             int
+	CacheCreationInputTokens int
+	CacheReadInputTokens     int
+	TotalTokens              int
+}
+
 // MessageList represents a paginated list of messages
 // @Description Paginated list of conversation messages
 type MessageList struct {

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -31,6 +31,25 @@ type CrashInfo struct {
 	TaskCompleted bool `json:"task_completed,omitempty"`
 }
 
+// Usage captures token consumption and cost estimate for a completed run.
+// Populated from the session's JSONL history after the run finishes.
+type Usage struct {
+	// Model identifier reported by Claude (e.g. "claude-opus-4-7-20260101").
+	// Empty when the model is unknown — cost estimation skipped in that case.
+	Model string `json:"model,omitempty"`
+
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	TotalTokens              int `json:"total_tokens"`
+
+	// EstimatedCostUSD is best-effort: tokens × Anthropic's published
+	// per-1M rates, summed across all four buckets. Zero when the model
+	// isn't recognized or no usage was reported.
+	EstimatedCostUSD float64 `json:"estimated_cost_usd"`
+}
+
 // Job represents an async execution job
 type Job struct {
 	ID          string     `json:"id"`
@@ -38,6 +57,7 @@ type Job struct {
 	Output      string     `json:"output,omitempty"`
 	Error       string     `json:"error,omitempty"`
 	SessionID   string     `json:"session_id,omitempty"`
+	Usage       *Usage     `json:"usage,omitempty"`
 	CrashInfo   *CrashInfo `json:"crash_info,omitempty"`
 	CreatedAt   time.Time  `json:"created_at"`
 	UpdatedAt   time.Time  `json:"updated_at"`
@@ -103,6 +123,22 @@ func (m *Manager) Update(id string, status Status, output, errMsg, sessionID str
 	job.Output = output
 	job.Error = errMsg
 	job.SessionID = sessionID
+	job.UpdatedAt = time.Now()
+}
+
+// SetUsage attaches token-usage / cost information to an existing job.
+// Called after the runner finishes and we've aggregated the session JSONL.
+// Silently no-ops when the job has been deleted or doesn't exist (the job
+// may have been cancelled while the runner was still going).
+func (m *Manager) SetUsage(id string, usage *Usage) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	job, ok := m.jobs[id]
+	if !ok {
+		return
+	}
+	job.Usage = usage
 	job.UpdatedAt = time.Now()
 }
 

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -1,0 +1,80 @@
+// Package pricing converts token usage into a USD cost estimate based on
+// published Anthropic API rates. The rates here are starting points; operators
+// who run on enterprise tiers or negotiated contracts should override them.
+package pricing
+
+import "strings"
+
+// Rates holds per-model token pricing in USD per 1M tokens.
+// CacheWrite and CacheRead are derived from input prices using Anthropic's
+// public multipliers (cache writes ≈ 1.25× input, cache reads ≈ 0.1× input)
+// when not overridden.
+type Rates struct {
+	InputPerMTok      float64
+	OutputPerMTok     float64
+	CacheWritePerMTok float64
+	CacheReadPerMTok  float64
+}
+
+// modelPrefixRates maps a lowercase substring of the model ID to its rates.
+// Entries are checked in order — list more specific prefixes first when the
+// table grows beyond the three current families.
+var modelPrefixRates = []struct {
+	prefix string
+	rates  Rates
+}{
+	{prefix: "haiku", rates: Rates{
+		InputPerMTok:      0.25,
+		OutputPerMTok:     1.25,
+		CacheWritePerMTok: 0.30,
+		CacheReadPerMTok:  0.025,
+	}},
+	{prefix: "sonnet", rates: Rates{
+		InputPerMTok:      3.00,
+		OutputPerMTok:     15.00,
+		CacheWritePerMTok: 3.75,
+		CacheReadPerMTok:  0.30,
+	}},
+	{prefix: "opus", rates: Rates{
+		InputPerMTok:      15.00,
+		OutputPerMTok:     75.00,
+		CacheWritePerMTok: 18.75,
+		CacheReadPerMTok:  1.50,
+	}},
+}
+
+// LookupRates returns the Rates for the given model identifier, plus a
+// boolean indicating whether the model was recognized. Unknown models get
+// a zero-value Rates so callers can still surface token counts without
+// emitting a misleading dollar figure.
+func LookupRates(model string) (Rates, bool) {
+	m := strings.ToLower(model)
+	for _, entry := range modelPrefixRates {
+		if strings.Contains(m, entry.prefix) {
+			return entry.rates, true
+		}
+	}
+	return Rates{}, false
+}
+
+// Tokens is a flat token-count snapshot, mirroring the fields Claude emits
+// per assistant message. The pricing package keeps a local copy of this shape
+// so it doesn't depend on the history package and can be reused by other
+// callers (e.g. webhook payloads).
+type Tokens struct {
+	Input         int
+	Output        int
+	CacheCreation int
+	CacheRead     int
+}
+
+// EstimateUSD returns the USD cost implied by the given token counts under
+// the given rates. All four token buckets contribute. Result is in dollars,
+// rounded by the caller (we keep full precision here).
+func EstimateUSD(t Tokens, r Rates) float64 {
+	const perMillion = 1_000_000.0
+	return float64(t.Input)*r.InputPerMTok/perMillion +
+		float64(t.Output)*r.OutputPerMTok/perMillion +
+		float64(t.CacheCreation)*r.CacheWritePerMTok/perMillion +
+		float64(t.CacheRead)*r.CacheReadPerMTok/perMillion
+}

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -1,0 +1,91 @@
+package pricing
+
+import (
+	"math"
+	"testing"
+)
+
+func TestLookupRates(t *testing.T) {
+	cases := []struct {
+		model       string
+		wantInput   float64
+		wantKnown   bool
+	}{
+		{"claude-haiku-4-5-20251001", 0.25, true},
+		{"claude-sonnet-4-6", 3.00, true},
+		{"claude-opus-4-7", 15.00, true},
+		{"CLAUDE-OPUS-4-7", 15.00, true},
+		{"some-future-tier", 0, false},
+		{"", 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.model, func(t *testing.T) {
+			r, ok := LookupRates(c.model)
+			if ok != c.wantKnown {
+				t.Fatalf("known=%v, want %v", ok, c.wantKnown)
+			}
+			if r.InputPerMTok != c.wantInput {
+				t.Fatalf("InputPerMTok=%v, want %v", r.InputPerMTok, c.wantInput)
+			}
+		})
+	}
+}
+
+func TestEstimateUSD(t *testing.T) {
+	rates := Rates{
+		InputPerMTok:      3.00,
+		OutputPerMTok:     15.00,
+		CacheWritePerMTok: 3.75,
+		CacheReadPerMTok:  0.30,
+	}
+
+	t.Run("zero tokens is zero cost", func(t *testing.T) {
+		got := EstimateUSD(Tokens{}, rates)
+		if got != 0 {
+			t.Fatalf("got %v, want 0", got)
+		}
+	})
+
+	t.Run("input + output", func(t *testing.T) {
+		// 1M input + 1M output should equal input + output rates.
+		got := EstimateUSD(Tokens{Input: 1_000_000, Output: 1_000_000}, rates)
+		want := 18.0
+		if math.Abs(got-want) > 1e-9 {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("cache buckets", func(t *testing.T) {
+		// 1M cache write + 1M cache read.
+		got := EstimateUSD(Tokens{CacheCreation: 1_000_000, CacheRead: 1_000_000}, rates)
+		want := 4.05
+		if math.Abs(got-want) > 1e-9 {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("realistic mix", func(t *testing.T) {
+		// 150 input + 42 output + 336 cache write + 18121 cache read at sonnet rates.
+		got := EstimateUSD(Tokens{
+			Input:         150,
+			Output:        42,
+			CacheCreation: 336,
+			CacheRead:     18121,
+		}, rates)
+		// Hand-computed:
+		// 150*3 + 42*15 + 336*3.75 + 18121*0.3 = 450 + 630 + 1260 + 5436.3 = 7776.3 / 1e6
+		want := 0.0077763
+		if math.Abs(got-want) > 1e-9 {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+}
+
+func TestEstimateUSD_UnknownModel(t *testing.T) {
+	// A zero-value Rates should give zero cost for any token counts, so
+	// callers fall back to surfacing tokens without a bogus dollar figure.
+	got := EstimateUSD(Tokens{Input: 1_000_000, Output: 1_000_000}, Rates{})
+	if got != 0 {
+		t.Fatalf("got %v, want 0", got)
+	}
+}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -6,15 +6,18 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"stromboli/internal/job"
 )
 
 // JobResult represents the result of a job to be sent to webhook
 type JobResult struct {
-	JobID     string `json:"job_id"`
-	Status    string `json:"status"`
-	Output    string `json:"output,omitempty"`
-	Error     string `json:"error,omitempty"`
-	SessionID string `json:"session_id,omitempty"`
+	JobID     string     `json:"job_id"`
+	Status    string     `json:"status"`
+	Output    string     `json:"output,omitempty"`
+	Error     string     `json:"error,omitempty"`
+	SessionID string     `json:"session_id,omitempty"`
+	Usage     *job.Usage `json:"usage,omitempty"`
 }
 
 // Notifier sends webhook notifications


### PR DESCRIPTION
## Summary
\`/run\` and \`/run/async\` now include a \`usage\` block on the response with token totals (input / output / cache-write / cache-read / total) plus a best-effort USD cost estimate. Webhook payloads carry the same field, so n8n flows and audit-cap consumers can track spend without a side-channel.

Closes #56

## What changed

### New package: \`internal/pricing\`
- Per-model rates for **haiku** ($0.25 / $1.25), **sonnet** ($3 / $15), **opus** ($15 / $75) per 1M input/output tokens
- Cache-write and cache-read rates derived from Anthropic's public 1.25× / 0.1× input multipliers
- Unknown models return zero rates → token counts still surface, USD stays at 0 instead of misleading

### \`internal/history\` — \`Reader.AggregateUsage\`
- Walks the session JSONL once, sums every assistant message's \`usage\` block
- Picks the most-recently-seen model identifier for cost lookup
- Returns \`(nil, nil)\` when usage hasn't been reported yet — that's a normal in-flight state, not an error

### \`internal/job\` — \`Job.Usage\` + \`Manager.SetUsage\`
- New \`Usage\` struct with the same fields as the spec, plus \`Model\` and \`EstimatedCostUSD\`
- \`SetUsage\` is called after the runner returns, so \`GET /jobs/:id\` includes the data too

### \`internal/api\` — wiring
- \`RunResponse.Usage\` (sync handler), \`Job.Usage\` (async handler), \`webhook.JobResult.Usage\` (callbacks)
- Centralized \`buildUsage\` helper so the aggregate→price→round flow lives in one place
- Cost is rounded to 6 decimals so JSON consumers don't see binary noise

## Tests
- \`internal/pricing\`: table-driven unit tests covering known/unknown models and four token-bucket combinations
- \`internal/history\`: fixture-based tests for missing session, no-usage, and multi-message-sum paths
- \`internal/api\`: e2e test that pre-writes a JSONL fixture, hits \`POST /run\`, and asserts model + tokens + USD cost
- Full \`go test -race ./...\` is green

## Behavior change
Existing API consumers see a new optional \`usage\` field on responses and webhooks. The field is omitted (nil) when:
- Session JSONL doesn't exist yet (run failed before producing output)
- No assistant message reported usage
- Aggregation errors (logged at debug, never blocks the response)

## Notes for review
- Pricing rates live in code rather than config — operators on enterprise tiers or negotiated contracts will want to override. Could add config hooks in a follow-up if requested.
- \`webhook\` package now imports \`internal/job\` for the Usage type. One-directional, no cycle. If you'd prefer keeping webhook decoupled, easy to flip to a duplicate inline struct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)