### PR TITLE
feat: expose --effort level via ClaudeOptions (#74)

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -2386,6 +2386,11 @@ const docTemplate = `{
                         "Write"
                     ]
                 },
+                "effort": {
+                    "description": "Effort level for thinking/agentic complexity. Valid values per the\nupstream CLI reference: low, medium, high, xhigh, max. The accepted\nsubset depends on the model — Claude rejects unsupported levels at\nruntime, so Stromboli does not gate on an enum here.",
+                    "type": "string",
+                    "example": "high"
+                },
                 "fallback_model": {
                     "description": "Fallback model when default is overloaded",
                     "type": "string",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -2380,6 +2380,11 @@
                         "Write"
                     ]
                 },
+                "effort": {
+                    "description": "Effort level for thinking/agentic complexity. Valid values per the\nupstream CLI reference: low, medium, high, xhigh, max. The accepted\nsubset depends on the model — Claude rejects unsupported levels at\nruntime, so Stromboli does not gate on an enum here.",
+                    "type": "string",
+                    "example": "high"
+                },
                 "fallback_model": {
                     "description": "Fallback model when default is overloaded",
                     "type": "string",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -839,6 +839,14 @@ definitions:
         items:
           type: string
         type: array
+      effort:
+        description: |-
+          Effort level for thinking/agentic complexity. Valid values per the
+          upstream CLI reference: low, medium, high, xhigh, max. The accepted
+          subset depends on the model — Claude rejects unsupported levels at
+          runtime, so Stromboli does not gate on an enum here.
+        example: high
+        type: string
       fallback_model:
         description: Fallback model when default is overloaded
         example: haiku

--- a/internal/claude/builder.go
+++ b/internal/claude/builder.go
@@ -22,6 +22,7 @@ type CommandBuilder struct {
 	// Model configuration
 	model         string // --model
 	fallbackModel string // --fallback-model
+	effort        string // --effort (low, medium, high, xhigh, max — model-dependent)
 
 	// System prompt
 	systemPrompt       string // --system-prompt
@@ -136,6 +137,15 @@ func (b *CommandBuilder) WithModel(model string) *CommandBuilder {
 // WithFallbackModel sets fallback model when default is overloaded
 func (b *CommandBuilder) WithFallbackModel(model string) *CommandBuilder {
 	b.fallbackModel = model
+	return b
+}
+
+// WithEffort sets the per-session effort level. Valid values per the CLI
+// reference are low, medium, high, xhigh, max — but the actual subset
+// accepted depends on the model, so we don't gate on an enum here. Claude
+// will reject unsupported values at runtime with a clear error.
+func (b *CommandBuilder) WithEffort(level string) *CommandBuilder {
+	b.effort = level
 	return b
 }
 
@@ -371,6 +381,9 @@ func (b *CommandBuilder) Build() []string {
 	}
 	if b.fallbackModel != "" {
 		args = append(args, "--fallback-model", b.fallbackModel)
+	}
+	if b.effort != "" {
+		args = append(args, "--effort", b.effort)
 	}
 
 	// System prompt

--- a/internal/claude/builder_test.go
+++ b/internal/claude/builder_test.go
@@ -85,6 +85,24 @@ func TestWithFallbackModel(t *testing.T) {
 	assert.Contains(t, cmd, "sonnet")
 }
 
+func TestWithEffort(t *testing.T) {
+	for _, level := range []string{"low", "medium", "high", "xhigh", "max"} {
+		t.Run(level, func(t *testing.T) {
+			cmd := NewCommandBuilder().
+				WithPrompt("test").
+				WithEffort(level).
+				Build()
+			assert.Contains(t, cmd, "--effort")
+			assert.Contains(t, cmd, level)
+		})
+	}
+}
+
+func TestWithEffort_OmittedWhenEmpty(t *testing.T) {
+	cmd := NewCommandBuilder().WithPrompt("test").Build()
+	assert.NotContains(t, cmd, "--effort")
+}
+
 func TestWithSystemPrompt(t *testing.T) {
 	cmd := NewCommandBuilder().
 		WithPrompt("hello").

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -777,13 +777,16 @@ func (r *PodmanRunner) applySessionOptions(b *claude.CommandBuilder, opts types.
 	}
 }
 
-// applyModelOptions handles Model, FallbackModel options
+// applyModelOptions handles Model, FallbackModel, Effort options
 func (r *PodmanRunner) applyModelOptions(b *claude.CommandBuilder, opts types.ClaudeOptions) {
 	if opts.Model != "" {
 		b.WithModel(opts.Model)
 	}
 	if opts.FallbackModel != "" {
 		b.WithFallbackModel(opts.FallbackModel)
+	}
+	if opts.Effort != "" {
+		b.WithEffort(opts.Effort)
 	}
 }
 

--- a/internal/types/options.go
+++ b/internal/types/options.go
@@ -22,6 +22,11 @@ type ClaudeOptions struct {
 	Model string `json:"model,omitempty" example:"sonnet"`
 	// Fallback model when default is overloaded
 	FallbackModel string `json:"fallback_model,omitempty" example:"haiku"`
+	// Effort level for thinking/agentic complexity. Valid values per the
+	// upstream CLI reference: low, medium, high, xhigh, max. The accepted
+	// subset depends on the model — Claude rejects unsupported levels at
+	// runtime, so Stromboli does not gate on an enum here.
+	Effort string `json:"effort,omitempty" example:"high"`
 
 	// --- System Prompt ---
 


### PR DESCRIPTION
## Summary
Threads Claude Code's recently-shipped \`--effort\` flag through Stromboli's HTTP surface. Callers pick \`low\` / \`medium\` / \`high\` / \`xhigh\` / \`max\` per request via a new \`effort\` field on \`ClaudeOptions\`.

Closes #74

## What changed
- \`internal/types/options.go\` — new \`Effort\` field on \`ClaudeOptions\`
- \`internal/claude/builder.go\` — \`effort\` field + \`WithEffort\` builder method + arg emission
- \`internal/runner/runner.go\` — \`applyModelOptions\` wires the option through
- \`internal/claude/builder_test.go\` — table-driven test across all five levels + omission test

## Why no enum validation?
Per the upstream CLI reference: "available levels depend on the model". Claude rejects unsupported values at runtime with a clear error. Doing our own enum check would give us a maintenance burden every time a new level ships and a worse error message than Claude's.

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./internal/claude/... ./internal/runner/... ./internal/api/...\` green
- [x] Swagger regenerated for the new field
- [ ] Smoke against a real claude: \`POST /run\` with \`{"claude":{"effort":"high"}}\` and confirm the spawned command includes \`--effort high\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)