### PR TITLE
feat: env-var passthrough for caching, Bedrock tier, and PowerShell (#76, #77, #81)

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -2349,6 +2349,11 @@ const docTemplate = `{
                     "type": "string",
                     "example": "Focus on security best practices"
                 },
+                "bedrock_service_tier": {
+                    "description": "Bedrock service tier when running against AWS Bedrock as the model\nbackend. Valid values: \"default\", \"flex\", \"priority\". Translates to\nANTHROPIC_BEDROCK_SERVICE_TIER. Ignored when not on Bedrock. (#77)",
+                    "type": "string",
+                    "example": "priority"
+                },
                 "betas": {
                     "description": "Beta headers for API requests",
                     "type": "array",
@@ -2385,6 +2390,11 @@ const docTemplate = `{
                     "example": [
                         "Write"
                     ]
+                },
+                "enable_powershell_tool": {
+                    "description": "Opt into Claude Code's native PowerShell tool on Windows agent hosts.\nTranslates to CLAUDE_CODE_USE_POWERSHELL_TOOL=1. No-op on non-Windows\ncontainers. (#81)",
+                    "type": "boolean",
+                    "example": false
                 },
                 "fallback_model": {
                     "description": "Fallback model when default is overloaded",
@@ -2461,6 +2471,11 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "prompt_caching_ttl": {
+                    "description": "Prompt cache TTL. \"\" leaves Claude's default; \"5m\" sets\nFORCE_PROMPT_CACHING_5M=1; \"1h\" sets ENABLE_PROMPT_CACHING_1H=1.\nUseful for long-lived agent loops where the same context is re-used\nacross many turns. (#76)",
+                    "type": "string",
+                    "example": "1h"
                 },
                 "replay_user_messages": {
                     "description": "Re-emit user messages on stdout",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -2343,6 +2343,11 @@
                     "type": "string",
                     "example": "Focus on security best practices"
                 },
+                "bedrock_service_tier": {
+                    "description": "Bedrock service tier when running against AWS Bedrock as the model\nbackend. Valid values: \"default\", \"flex\", \"priority\". Translates to\nANTHROPIC_BEDROCK_SERVICE_TIER. Ignored when not on Bedrock. (#77)",
+                    "type": "string",
+                    "example": "priority"
+                },
                 "betas": {
                     "description": "Beta headers for API requests",
                     "type": "array",
@@ -2379,6 +2384,11 @@
                     "example": [
                         "Write"
                     ]
+                },
+                "enable_powershell_tool": {
+                    "description": "Opt into Claude Code's native PowerShell tool on Windows agent hosts.\nTranslates to CLAUDE_CODE_USE_POWERSHELL_TOOL=1. No-op on non-Windows\ncontainers. (#81)",
+                    "type": "boolean",
+                    "example": false
                 },
                 "fallback_model": {
                     "description": "Fallback model when default is overloaded",
@@ -2455,6 +2465,11 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "prompt_caching_ttl": {
+                    "description": "Prompt cache TTL. \"\" leaves Claude's default; \"5m\" sets\nFORCE_PROMPT_CACHING_5M=1; \"1h\" sets ENABLE_PROMPT_CACHING_1H=1.\nUseful for long-lived agent loops where the same context is re-used\nacross many turns. (#76)",
+                    "type": "string",
+                    "example": "1h"
                 },
                 "replay_user_messages": {
                     "description": "Re-emit user messages on stdout",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -811,6 +811,13 @@ definitions:
         description: Append to default system prompt
         example: Focus on security best practices
         type: string
+      bedrock_service_tier:
+        description: |-
+          Bedrock service tier when running against AWS Bedrock as the model
+          backend. Valid values: "default", "flex", "priority". Translates to
+          ANTHROPIC_BEDROCK_SERVICE_TIER. Ignored when not on Bedrock. (#77)
+        example: priority
+        type: string
       betas:
         description: Beta headers for API requests
         items:
@@ -839,6 +846,13 @@ definitions:
         items:
           type: string
         type: array
+      enable_powershell_tool:
+        description: |-
+          Opt into Claude Code's native PowerShell tool on Windows agent hosts.
+          Translates to CLAUDE_CODE_USE_POWERSHELL_TOOL=1. No-op on non-Windows
+          containers. (#81)
+        example: false
+        type: boolean
       fallback_model:
         description: Fallback model when default is overloaded
         example: haiku
@@ -901,6 +915,14 @@ definitions:
         items:
           type: string
         type: array
+      prompt_caching_ttl:
+        description: |-
+          Prompt cache TTL. "" leaves Claude's default; "5m" sets
+          FORCE_PROMPT_CACHING_5M=1; "1h" sets ENABLE_PROMPT_CACHING_1H=1.
+          Useful for long-lived agent loops where the same context is re-used
+          across many turns. (#76)
+        example: 1h
+        type: string
       replay_user_messages:
         description: Re-emit user messages on stdout
         example: false

--- a/internal/runner/env_test.go
+++ b/internal/runner/env_test.go
@@ -1,0 +1,60 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"stromboli/internal/podman"
+	"stromboli/internal/types"
+)
+
+func TestApplyClaudeEnvVars_PromptCachingTTL(t *testing.T) {
+	cases := map[string]struct {
+		ttl    string
+		envKey string
+		envSet bool
+	}{
+		"1h":                             {ttl: "1h", envKey: "ENABLE_PROMPT_CACHING_1H", envSet: true},
+		"5m":                             {ttl: "5m", envKey: "FORCE_PROMPT_CACHING_5M", envSet: true},
+		"unset/default":                  {ttl: "", envKey: "ENABLE_PROMPT_CACHING_1H", envSet: false},
+		"unknown value silently ignored": {ttl: "30m", envKey: "ENABLE_PROMPT_CACHING_1H", envSet: false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			b := podman.NewCommand().WithImage("test-image")
+			applyClaudeEnvVars(b, types.ClaudeOptions{PromptCachingTTL: tc.ttl})
+			cmd := strings.Join(b.Build(), " ")
+			if tc.envSet {
+				assert.Contains(t, cmd, "-e "+tc.envKey+"=1")
+			} else {
+				assert.NotContains(t, cmd, tc.envKey)
+			}
+		})
+	}
+}
+
+func TestApplyClaudeEnvVars_BedrockServiceTier(t *testing.T) {
+	b := podman.NewCommand().WithImage("test-image")
+	applyClaudeEnvVars(b, types.ClaudeOptions{BedrockServiceTier: "priority"})
+	cmd := strings.Join(b.Build(), " ")
+	assert.Contains(t, cmd, "-e ANTHROPIC_BEDROCK_SERVICE_TIER=priority")
+}
+
+func TestApplyClaudeEnvVars_PowerShellTool(t *testing.T) {
+	b := podman.NewCommand().WithImage("test-image")
+	applyClaudeEnvVars(b, types.ClaudeOptions{EnablePowerShellTool: true})
+	cmd := strings.Join(b.Build(), " ")
+	assert.Contains(t, cmd, "-e CLAUDE_CODE_USE_POWERSHELL_TOOL=1")
+}
+
+func TestApplyClaudeEnvVars_AllOff(t *testing.T) {
+	b := podman.NewCommand().WithImage("test-image")
+	applyClaudeEnvVars(b, types.ClaudeOptions{})
+	cmd := strings.Join(b.Build(), " ")
+	assert.NotContains(t, cmd, "ENABLE_PROMPT_CACHING_1H")
+	assert.NotContains(t, cmd, "FORCE_PROMPT_CACHING_5M")
+	assert.NotContains(t, cmd, "ANTHROPIC_BEDROCK_SERVICE_TIER")
+	assert.NotContains(t, cmd, "CLAUDE_CODE_USE_POWERSHELL_TOOL")
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -726,7 +726,29 @@ func (r *PodmanRunner) applyRequestConfig(req Request, podmanBuilder *podman.Com
 		podmanBuilder.WithCPUShares(*req.Podman.CPUShares)
 	}
 
+	// Apply Claude-side env vars (prompt caching, Bedrock tier, PowerShell tool).
+	// These are env-var-only knobs; the CLI has no flag for them.
+	applyClaudeEnvVars(podmanBuilder, req.Claude)
+
 	return nil
+}
+
+// applyClaudeEnvVars translates Claude-side env-var-only options into podman
+// `-e KEY=VALUE` injections. Each option is opt-in — empty string / false
+// leaves the variable unset so the CLI sees its native default.
+func applyClaudeEnvVars(b *podman.CommandBuilder, opts types.ClaudeOptions) {
+	switch opts.PromptCachingTTL {
+	case "1h":
+		b.WithEnv("ENABLE_PROMPT_CACHING_1H", "1")
+	case "5m":
+		b.WithEnv("FORCE_PROMPT_CACHING_5M", "1")
+	}
+	if opts.BedrockServiceTier != "" {
+		b.WithEnv("ANTHROPIC_BEDROCK_SERVICE_TIER", opts.BedrockServiceTier)
+	}
+	if opts.EnablePowerShellTool {
+		b.WithEnv("CLAUDE_CODE_USE_POWERSHELL_TOOL", "1")
+	}
 }
 
 // RunAsync executes Claude in a goroutine and calls onComplete when done

--- a/internal/types/options.go
+++ b/internal/types/options.go
@@ -106,6 +106,24 @@ type ClaudeOptions struct {
 	// Beta headers for API requests
 	Betas []string `json:"betas,omitempty"`
 
+	// --- Provider / Runtime Tuning (env-var-backed) ---
+
+	// Prompt cache TTL. "" leaves Claude's default; "5m" sets
+	// FORCE_PROMPT_CACHING_5M=1; "1h" sets ENABLE_PROMPT_CACHING_1H=1.
+	// Useful for long-lived agent loops where the same context is re-used
+	// across many turns. (#76)
+	PromptCachingTTL string `json:"prompt_caching_ttl,omitempty" example:"1h"`
+
+	// Bedrock service tier when running against AWS Bedrock as the model
+	// backend. Valid values: "default", "flex", "priority". Translates to
+	// ANTHROPIC_BEDROCK_SERVICE_TIER. Ignored when not on Bedrock. (#77)
+	BedrockServiceTier string `json:"bedrock_service_tier,omitempty" example:"priority"`
+
+	// Opt into Claude Code's native PowerShell tool on Windows agent hosts.
+	// Translates to CLAUDE_CODE_USE_POWERSHELL_TOOL=1. No-op on non-Windows
+	// containers. (#81)
+	EnablePowerShellTool bool `json:"enable_powershell_tool,omitempty" example:"false"`
+
 	// --- Misc ---
 
 	// Enable verbose mode


### PR DESCRIPTION
## Summary
Three Claude Code knobs that live as environment variables (not CLI flags) and were previously unreachable through Stromboli's HTTP surface:

| ClaudeOptions field | Env var translated to | Issue |
|---|---|---|
| \`prompt_caching_ttl: "1h"\` | \`ENABLE_PROMPT_CACHING_1H=1\` | #76 |
| \`prompt_caching_ttl: "5m"\` | \`FORCE_PROMPT_CACHING_5M=1\` | #76 |
| \`bedrock_service_tier: "priority"\` | \`ANTHROPIC_BEDROCK_SERVICE_TIER=priority\` | #77 |
| \`enable_powershell_tool: true\` | \`CLAUDE_CODE_USE_POWERSHELL_TOOL=1\` | #81 |

Each opts in only when the field is set / non-empty so callers don't get behavior they didn't ask for. \`PromptCachingTTL\` silently ignores unknown values (forward-compatible if Anthropic adds another tier).

Closes #76, #77, #81

## Implementation
- \`internal/types/options.go\` — three new \`ClaudeOptions\` fields with docs explaining the env-var mapping
- \`internal/runner/runner.go\` — \`applyClaudeEnvVars\` helper called from \`applyRequestConfig\`; injects \`-e KEY=VALUE\` on the podman command builder
- \`internal/runner/env_test.go\` — table-driven unit tests for each path + an "all off = no env vars" guard

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./internal/runner/...\` green (5 new tests)
- [x] Full \`go test -race ./...\` still green
- [x] Swagger regenerated for the three new fields
- [ ] Smoke against a Bedrock-backed deployment for \`bedrock_service_tier\`
- [ ] Confirm \`ENABLE_PROMPT_CACHING_1H=1\` actually changes Claude's caching behavior on a long agent loop (subjective — needs a real workload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)