### PR TITLE
feat: surface session title from UserPromptSubmit hook (#83)

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1845,8 +1845,23 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_api.SessionInfo": {
+            "description": "Metadata about a single session",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "example": "sess-abc123"
+                },
+                "title": {
+                    "description": "Title is set by a UserPromptSubmit hook returning\nhookSpecificOutput.sessionTitle (or by /rename in interactive mode).\nEmpty when no title was ever set for this session.",
+                    "type": "string",
+                    "example": "Refactor billing service"
+                }
+            }
+        },
         "internal_api.SessionListResponse": {
-            "description": "List of existing sessions",
+            "description": "List of existing sessions with metadata",
             "type": "object",
             "properties": {
                 "error": {
@@ -1855,12 +1870,8 @@ const docTemplate = `{
                 "sessions": {
                     "type": "array",
                     "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "sess-abc123",
-                        "sess-def456"
-                    ]
+                        "$ref": "#/definitions/internal_api.SessionInfo"
+                    }
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1839,8 +1839,23 @@
                 }
             }
         },
+        "internal_api.SessionInfo": {
+            "description": "Metadata about a single session",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "example": "sess-abc123"
+                },
+                "title": {
+                    "description": "Title is set by a UserPromptSubmit hook returning\nhookSpecificOutput.sessionTitle (or by /rename in interactive mode).\nEmpty when no title was ever set for this session.",
+                    "type": "string",
+                    "example": "Refactor billing service"
+                }
+            }
+        },
         "internal_api.SessionListResponse": {
-            "description": "List of existing sessions",
+            "description": "List of existing sessions with metadata",
             "type": "object",
             "properties": {
                 "error": {
@@ -1849,12 +1864,8 @@
                 "sessions": {
                     "type": "array",
                     "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "sess-abc123",
-                        "sess-def456"
-                    ]
+                        "$ref": "#/definitions/internal_api.SessionInfo"
+                    }
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -434,17 +434,28 @@ definitions:
         example: true
         type: boolean
     type: object
+  internal_api.SessionInfo:
+    description: Metadata about a single session
+    properties:
+      id:
+        example: sess-abc123
+        type: string
+      title:
+        description: |-
+          Title is set by a UserPromptSubmit hook returning
+          hookSpecificOutput.sessionTitle (or by /rename in interactive mode).
+          Empty when no title was ever set for this session.
+        example: Refactor billing service
+        type: string
+    type: object
   internal_api.SessionListResponse:
-    description: List of existing sessions
+    description: List of existing sessions with metadata
     properties:
       error:
         type: string
       sessions:
-        example:
-        - sess-abc123
-        - sess-def456
         items:
-          type: string
+          $ref: '#/definitions/internal_api.SessionInfo'
         type: array
     type: object
   internal_api.SessionMessageResponse:

--- a/internal/api/run.go
+++ b/internal/api/run.go
@@ -83,11 +83,21 @@ func extractStructuredOutput(output string) json.RawMessage {
 	return envelope.StructuredOutput
 }
 
+// SessionInfo carries metadata about a session in list responses.
+// @Description Metadata about a single session
+type SessionInfo struct {
+	ID    string `json:"id" example:"sess-abc123"`
+	// Title is set by a UserPromptSubmit hook returning
+	// hookSpecificOutput.sessionTitle (or by /rename in interactive mode).
+	// Empty when no title was ever set for this session.
+	Title string `json:"title,omitempty" example:"Refactor billing service"`
+}
+
 // SessionListResponse represents the response from listing sessions
-// @Description List of existing sessions
+// @Description List of existing sessions with metadata
 type SessionListResponse struct {
-	Sessions []string `json:"sessions" example:"sess-abc123,sess-def456"`
-	Error    string   `json:"error,omitempty"`
+	Sessions []SessionInfo `json:"sessions"`
+	Error    string        `json:"error,omitempty"`
 }
 
 // SessionDestroyResponse represents the response from destroying a session

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -257,8 +257,23 @@ func (s *Server) listSessions(c *gin.Context) {
 		return
 	}
 
+	// Decorate each session ID with its title (when the JSONL recorded one
+	// via a UserPromptSubmit sessionTitle hook). Title lookup is best-effort
+	// — a missing or unreadable JSONL surfaces an empty title, never an error,
+	// so a single broken session doesn't fail the whole list response.
+	infos := make([]SessionInfo, 0, len(sessions))
+	for _, id := range sessions {
+		info := SessionInfo{ID: id}
+		if s.historyHandler != nil {
+			if t, _ := s.historyHandler.Reader().GetTitle(id); t != "" {
+				info.Title = t
+			}
+		}
+		infos = append(infos, info)
+	}
+
 	c.JSON(http.StatusOK, SessionListResponse{
-		Sessions: sessions,
+		Sessions: infos,
 	})
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -503,9 +503,13 @@ func TestListSessions_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Len(t, response.Sessions, 3)
-	assert.Contains(t, response.Sessions, "sess-1")
-	assert.Contains(t, response.Sessions, "sess-2")
-	assert.Contains(t, response.Sessions, "sess-3")
+	ids := make([]string, len(response.Sessions))
+	for i, s := range response.Sessions {
+		ids[i] = s.ID
+	}
+	assert.Contains(t, ids, "sess-1")
+	assert.Contains(t, ids, "sess-2")
+	assert.Contains(t, ids, "sess-3")
 }
 
 func TestListSessions_Empty(t *testing.T) {
@@ -716,4 +720,54 @@ func TestRun_PopulatesUsage(t *testing.T) {
 	assert.Equal(t, 1200, resp.Usage.TotalTokens)
 	// 1000 input @ $3/1M + 200 output @ $15/1M = 0.003 + 0.003 = 0.006
 	assert.InDelta(t, 0.006, resp.Usage.EstimatedCostUSD, 1e-9)
+}
+
+func TestListSessions_SurfacesTitleFromJSONL(t *testing.T) {
+	tmpDir := t.TempDir()
+	secretsFile := filepath.Join(tmpDir, ".claude-secrets")
+	sessionsDir := filepath.Join(tmpDir, "sessions")
+	require.NoError(t, os.WriteFile(secretsFile, []byte("test-token"), 0600))
+
+	const sessionID = "sess-titled"
+	jsonlDir := filepath.Join(sessionsDir, sessionID, ".claude", "projects", "-workspace")
+	require.NoError(t, os.MkdirAll(jsonlDir, 0755))
+	// Two custom-title entries — the API should surface the LATER one.
+	jsonl := `{"type":"custom-title","customTitle":"first-title","sessionId":"sess-titled"}
+{"type":"user","uuid":"u1","sessionId":"sess-titled","timestamp":"2026-01-24T10:00:00.000Z","message":{"role":"user","content":"hi"}}
+{"type":"custom-title","customTitle":"final-title","sessionId":"sess-titled"}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(jsonlDir, sessionID+".jsonl"), []byte(jsonl), 0644))
+
+	mockRunner := &runner.MockRunner{
+		ListSessionsFunc: func() ([]string, error) {
+			return []string{"sess-titled", "sess-untitled"}, nil
+		},
+	}
+	claudeClient := claude.NewClient(secretsFile)
+	jobMgr := job.NewManager()
+	server := NewServer(
+		mockRunner, claudeClient,
+		auth.Config{Enabled: false}, RateLimitConfig{Enabled: false},
+		jobMgr, nil, nil, false, sessionsDir,
+		secrets.NewRegistry(&mockTestExecutor{}),
+		images.NewRegistry(&mockTestExecutor{}),
+		nil,
+	)
+
+	req, err := http.NewRequest(http.MethodGet, "/sessions", nil)
+	require.NoError(t, err)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp SessionListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Sessions, 2)
+
+	titles := map[string]string{}
+	for _, s := range resp.Sessions {
+		titles[s.ID] = s.Title
+	}
+	assert.Equal(t, "final-title", titles["sess-titled"], "latest custom-title entry should win")
+	assert.Equal(t, "", titles["sess-untitled"], "session without a title gets empty Title")
 }

--- a/internal/history/reader.go
+++ b/internal/history/reader.go
@@ -196,6 +196,55 @@ func (r *Reader) GetMessage(sessionID, messageUUID string) (*Message, error) {
 	return nil, fmt.Errorf("message not found: %s", messageUUID)
 }
 
+// GetTitle reads the session's JSONL and returns the latest title set by a
+// UserPromptSubmit hook (via hookSpecificOutput.sessionTitle, which Claude
+// persists as `{"type":"custom-title","customTitle":"…","sessionId":"…"}`
+// entries). Returns "" + nil if the session has no title — that's a normal
+// state, not an error. Only filesystem / read errors are surfaced as err.
+func (r *Reader) GetTitle(sessionID string) (string, error) {
+	filePath, err := r.findSessionFile(sessionID)
+	if err != nil {
+		// Session file missing is treated as "no title" — most callers
+		// don't care, and a 404 in the title path shouldn't break the
+		// surrounding list response.
+		return "", nil
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open session file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 0, 1024*1024)
+	scanner.Buffer(buf, 10*1024*1024)
+
+	// Multiple custom-title entries may exist (hook fires per turn). Keep
+	// the last one we see — that's the most recent rename.
+	var probe struct {
+		Type        string `json:"type"`
+		CustomTitle string `json:"customTitle"`
+	}
+	latest := ""
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		if err := json.Unmarshal(line, &probe); err != nil {
+			continue
+		}
+		if probe.Type == "custom-title" && probe.CustomTitle != "" {
+			latest = probe.CustomTitle
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error reading session file: %w", err)
+	}
+	return latest, nil
+}
+
 // AggregateUsage walks the session JSONL once and sums every assistant
 // message's `usage` block. Returns the totals plus the most recently seen
 // model identifier (used for cost estimation).


### PR DESCRIPTION
## Summary
\`GET /sessions\` now surfaces a \`title\` per session, sourced from the JSONL \`custom-title\` entries Claude Code writes when a UserPromptSubmit hook returns \`hookSpecificOutput.sessionTitle\`.

Closes #83

## How I confirmed the storage shape
Ran a real \`claude\` 2.1.123 session locally with a UserPromptSubmit hook emitting \`{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"","sessionTitle":"PROBE"}}\` and inspected \`~/.claude/projects/<workspace>/<sid>.jsonl\`. Two flat entries appear (duplicated per hook fire):

\`\`\`jsonc
{"type":"custom-title","customTitle":"PROBE","sessionId":"..."}
{"type":"agent-name",  "agentName":"PROBE",  "sessionId":"..."}
\`\`\`

We parse \`custom-title\` (canonical) and take the **latest** entry — supports the rename-mid-session flow. \`agent-name\` is the legacy form and carries the same value.

### Doc gap surfaced during the probe
The upstream docs omit two **required** fields next to \`sessionTitle\`. Without them claude logs a non-blocking validation error and drops the title. Full payload:
\`\`\`json
{"hookSpecificOutput":{
  "hookEventName":"UserPromptSubmit",
  "additionalContext":"",
  "sessionTitle":"<title>"
}}
\`\`\`
The commit message captures this so future readers don't repeat the experiment.

## Breaking API change (pre-1.0)
\`SessionListResponse.Sessions\` shifts from \`[]string\` to \`[]SessionInfo{ID, Title}\`. Existing consumers parsing the old shape need a one-line update; \`Title\` is omitted (empty) when the session has no \`custom-title\` entry.

## What changed
- \`internal/history/reader.go\` — \`Reader.GetTitle\` walks the JSONL and returns the latest \`custom-title\` (or \`""\` + nil if untitled)
- \`internal/api/run.go\` — new \`SessionInfo\` struct + updated \`SessionListResponse\`
- \`internal/api/server.go\` — \`listSessions\` decorates each ID with its title (best-effort; a single broken JSONL surfaces as empty title, never fails the list response)
- \`internal/api/server_test.go\` — existing test updated for the new shape; new test verifies latest-wins title selection
- \`docs/swagger/\` — regenerated

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./internal/history/... ./internal/api/...\` green
- [x] Manually validated against a real claude 2.1.123 session
- [ ] Smoke against a multi-rename session — confirm the latest title wins after several \`/rename\` operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)