### PR TITLE
docs: align config defaults, add /agents endpoints, refresh changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,19 +218,26 @@ curl -X POST http://localhost:8080/run \
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `STROMBOLI_AUTH_ENABLED` | `false` | Enable token-based authentication |
+| `STROMBOLI_AUTH_ENABLED` | `true` | Enable token-based authentication. Server fails fast on startup if a JWT secret is missing/empty/placeholder. |
 | `STROMBOLI_API_TOKENS` | - | Comma-separated list of valid API tokens |
-| `STROMBOLI_JWT_SECRET` | - | Secret key for JWT signing (enables JWT auth) |
+| `STROMBOLI_JWT_SECRET` | - | Secret key for JWT signing (required when auth is enabled — must be ≥32 chars, no placeholders) |
 | `STROMBOLI_JWT_EXPIRY` | `24h` | JWT access token lifetime |
 | `STROMBOLI_RATE_LIMIT_ENABLED` | `false` | Enable rate limiting |
 | `STROMBOLI_RATE_LIMIT_RPS` | `10` | Requests per second limit |
 | `STROMBOLI_RATE_LIMIT_BURST` | `20` | Maximum burst size |
 | `STROMBOLI_TRACING_ENABLED` | `false` | Enable OpenTelemetry tracing |
 | `STROMBOLI_TRACING_ENDPOINT` | `localhost:4317` | OTLP collector endpoint |
+| `STROMBOLI_TRACING_INSECURE` | `false` | Disable TLS for the OTLP exporter (insecure — dev only) |
+| `STROMBOLI_METRICS_ENABLED` | `true` | Expose Prometheus metrics on a separate listener |
+| `STROMBOLI_METRICS_ADDRESS` | `127.0.0.1:9090` | Metrics listener bind address (localhost-only by default; never share-listen on `0.0.0.0`) |
+| `STROMBOLI_LOG_FORMAT` | `json` | Log encoder (`json` or `text`) |
+| `STROMBOLI_LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
 
 ### Authentication
 
-When `STROMBOLI_AUTH_ENABLED=true`, include a Bearer token:
+Auth is **enabled by default**. Stromboli refuses to start if `STROMBOLI_JWT_SECRET` is missing/empty or a known placeholder — set a real secret (`openssl rand -base64 32`) before launching. Set `STROMBOLI_AUTH_ENABLED=false` only for local dev.
+
+Include a Bearer token on every request:
 
 ```bash
 curl -X POST http://localhost:8080/run \

--- a/deployments/kubernetes/configmap.yaml
+++ b/deployments/kubernetes/configmap.yaml
@@ -49,12 +49,16 @@ data:
   STROMBOLI_RATE_LIMIT_BURST: "20"
 
   # ---------------------------------------------------------------------------
-  # Metrics — bound to 0.0.0.0:9090 inside the pod, but the Service does not
-  # expose it externally. Reach it from a Prometheus scrape sidecar / pod, or
-  # add a separate ClusterIP Service if you need cross-namespace scraping.
+  # Metrics — bound to 127.0.0.1:9090 inside the pod by default. The Service
+  # does not expose it externally; scrape it via a Prometheus sidecar in the
+  # same pod (loopback access) or run a `kubectl port-forward` for local debug.
+  # If you genuinely need cross-pod scraping (e.g. an in-cluster Prometheus
+  # without sidecar injection), override this to "0.0.0.0:9090" AND add a
+  # NetworkPolicy that restricts ingress on 9090 to the Prometheus pod only —
+  # otherwise any compromised workload in the cluster can scrape the metrics.
   # ---------------------------------------------------------------------------
   STROMBOLI_METRICS_ENABLED: "true"
-  STROMBOLI_METRICS_ADDRESS: "0.0.0.0:9090"
+  STROMBOLI_METRICS_ADDRESS: "127.0.0.1:9090"
 
   # ---------------------------------------------------------------------------
   # Job cleanup

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -27,6 +27,7 @@ Run Claude synchronously.
     "output_format": "json",
     "max_budget_usd": 5.00,
     "max_turns": 30,
+    "effort": "high",
     "dangerously_skip_permissions": false
   },
   "podman": {
@@ -61,11 +62,31 @@ Run Claude synchronously.
   "status": "completed",
   "output": "Claude's response...",
   "structured_output": {"key": "value"},
-  "session_id": "550e8400-e29b-41d4-a716-446655440000"
+  "session_id": "550e8400-e29b-41d4-a716-446655440000",
+  "usage": {
+    "token_usage": {
+      "input_tokens": 1234,
+      "output_tokens": 567,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 8901
+    },
+    "estimated_cost_usd": 0.0142
+  }
 }
 ```
 
 `structured_output` is populated when using `output_format: "json"` with a `json_schema`. It extracts the parsed JSON from Claude's response envelope.
+
+`usage` reports the cumulative token totals for the session (read best-effort from the session JSONL) plus an `estimated_cost_usd` derived from the per-model price table. It is omitted when no assistant message has reported usage yet.
+
+#### Notable request fields
+
+| Field | Type | Description |
+|---|---|---|
+| `claude.effort` | string | Thinking/agentic complexity level. Per the upstream CLI: `low`, `medium`, `high`, `xhigh`, `max`. The accepted subset depends on the model — Stromboli passes through; Claude rejects unsupported levels at runtime. |
+| `claude.prompt_caching_ttl` | string | `"5m"` enables `FORCE_PROMPT_CACHING_5M=1`, `"1h"` enables `ENABLE_PROMPT_CACHING_1H=1`. Useful for long-lived agent loops re-using the same context. |
+| `claude.bedrock_service_tier` | string | `default` / `flex` / `priority` — sets `ANTHROPIC_BEDROCK_SERVICE_TIER`. Ignored when not on Bedrock. |
+| `claude.enable_powershell_tool` | bool | Sets `CLAUDE_CODE_USE_POWERSHELL_TOOL=1`. No-op on non-Windows containers. |
 
 | Error Status | Cause |
 |---|---|
@@ -173,8 +194,15 @@ Cancel a job.
 
 ## GET /sessions
 
+Returns each session's ID and (optional) human title. Titles are populated when an agent's `UserPromptSubmit` hook returns `hookSpecificOutput.sessionTitle` — Claude Code's interactive `/rename` does this automatically; headless callers can replicate it via a settings file.
+
 ```json
-{"sessions": ["550e8400-...", "6ba7b810-..."]}
+{
+  "sessions": [
+    {"id": "550e8400-...", "title": "Refactor billing service"},
+    {"id": "6ba7b810-...", "title": ""}
+  ]
+}
 ```
 
 ---
@@ -203,6 +231,20 @@ Cancel a job.
   "total": 2
 }
 ```
+
+---
+
+## GET /sessions/:id/messages/:message_id
+
+Fetch a single message from a session by its ID. Useful for retrieving large assistant outputs without re-reading the whole transcript.
+
+```json
+{"role": "assistant", "content": "...", "id": "msg-abc"}
+```
+
+| Error Status | Cause |
+|---|---|
+| 404 | Session or message not found |
 
 ---
 
@@ -310,3 +352,116 @@ Inspect a specific image (e.g., `python:3.12-slim`).
 ```json
 {"success": true, "image_id": "sha256:abc123...", "image": "python:3.12"}
 ```
+
+---
+
+## Persistent Agents
+
+Long-lived Claude processes for event-driven workloads (sensor buses, on-call bots, anything that needs sub-second turn latency instead of the 2–3 s cold start of `/run`). One agent = one container = one Claude process running with stream-json I/O. Agents stay alive across many `/send` turns until DELETE or the idle timeout fires.
+
+### POST /agents
+
+Spawn a new agent.
+
+```json
+{
+  "prompt": "You are an on-call assistant. Wait for incident reports.",
+  "workdir": "/workspace",
+  "idle_timeout_seconds": 1800,
+  "claude": {
+    "model": "sonnet",
+    "allowed_tools": ["Read", "Bash"]
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `prompt` | string | Optional first turn. If omitted, the agent boots empty and waits for `/send`. |
+| `workdir` | string | Working directory inside the container. |
+| `idle_timeout_seconds` | int | Override the manager-wide default. `0` = use default; negatives are rejected. |
+| `claude` | object | Free-form Claude CLI options (same shape as `RunRequest.claude`). |
+
+```json
+{
+  "id": "agent-abc123",
+  "session_id": "550e8400-...",
+  "status": "starting",
+  "created_at": "2026-05-01T08:00:00Z",
+  "last_activity_at": "2026-05-01T08:00:00Z",
+  "idle_timeout_seconds": 1800,
+  "turns_completed": 0
+}
+```
+
+| Status | Meaning |
+|---|---|
+| `starting` | Container booting; Claude hasn't reported readiness yet. |
+| `idle` | Alive and ready to accept the next turn. |
+| `generating` | A turn is in flight. Further `/send` returns `409`. |
+| `exited` | The process or container has stopped (clean or crashed). Record persists briefly so callers can read `exit_error`. |
+
+| Error Status | Cause |
+|---|---|
+| 400 | Invalid request body |
+| 500 | Spawn failed |
+
+### GET /agents
+
+List every registered agent.
+
+```json
+[{"id": "agent-abc123", "status": "idle", "...": "..."}]
+```
+
+### GET /agents/:id
+
+Inspect one agent. Returns the same `Snapshot` shape as `POST /agents`.
+
+| Error Status | Cause |
+|---|---|
+| 404 | Agent not found |
+
+### POST /agents/:id/send
+
+Append a prompt to a running agent. Returns immediately; output streams via `/stream`.
+
+```json
+{"prompt": "What's the status of incident INC-417?"}
+```
+
+```json
+{"turn_id": "turn-abc"}
+```
+
+| Error Status | Cause |
+|---|---|
+| 400 | Invalid request body |
+| 404 | Agent not found |
+| 409 | Turn already in progress (`ErrAgentBusy`) |
+| 410 | Agent has exited (`ErrAgentExited`) |
+| 503 | Agent not ready yet (`ErrAgentNotReady` — still in `starting`) |
+
+### GET /agents/:id/stream
+
+Server-Sent Events stream of agent output. Each event mirrors `agent.Event`:
+
+```
+event: turn_start
+data: {"type":"turn_start","turn_id":"turn-abc","at":"..."}
+
+event: output
+data: {"type":"output","turn_id":"turn-abc","content":"Hello","at":"..."}
+
+event: turn_end
+data: {"type":"turn_end","turn_id":"turn-abc","at":"..."}
+
+event: closed
+data: {}
+```
+
+Event types: `turn_start`, `output`, `turn_end`, `error`, `exited`. The `closed` event fires when the subscription ends because the agent was stopped/deleted.
+
+### DELETE /agents/:id
+
+Stop the agent and free resources. Returns `204 No Content` on success, `404` if not found.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,34 @@ All notable changes to Stromboli will be documented here.
 
 ### Added
 
+#### Persistent Agents
+- New `/agents/*` endpoint family for long-lived Claude processes with stream-json I/O — sub-second turn latency for event-driven workloads (sensor buses, on-call bots). See [API endpoints](api/endpoints.md#persistent-agents). (#60, #73)
+- Per-session token usage and estimated USD cost surfaced on `RunResponse.usage` (read from session JSONL, best-effort). (#56, #72)
+- `claude.effort` request field exposes the upstream CLI's thinking/agentic complexity level (`low`, `medium`, `high`, `xhigh`, `max` — accepted subset depends on model). (#74, #84)
+- Env-var passthrough for runtime tuning: `claude.prompt_caching_ttl` (`5m`/`1h`), `claude.bedrock_service_tier`, `claude.enable_powershell_tool`. (#76, #77, #81, #85)
+- Session titles surfaced from a `UserPromptSubmit` hook returning `hookSpecificOutput.sessionTitle`. `GET /sessions` now returns `{id, title}` records. (#83, #86)
+- New `GET /sessions/:id/messages/:message_id` endpoint to fetch a single message without re-reading the whole transcript.
+
+### Changed
+
+- **BREAKING (operational): Auth enabled by default.** `STROMBOLI_AUTH_ENABLED` now defaults to `true`. The server fails fast at startup if `STROMBOLI_JWT_SECRET` is empty, shorter than 32 chars, or matches a known placeholder. Existing setups must either set a real JWT secret or explicitly opt out with `STROMBOLI_AUTH_ENABLED=false`. (#45, #64)
+- **Logs are JSON by default** so log aggregators can parse them without preprocessing. Set `STROMBOLI_LOG_FORMAT=text` for human-friendly output during local dev. (#47, #65)
+- **Log level configurable** via `STROMBOLI_LOG_LEVEL` (`debug`/`info`/`warn`/`error`). (#48, #67)
+- **Tracing TLS by default**: `STROMBOLI_TRACING_INSECURE` now defaults to `false`. Plaintext OTLP only in dev. (#49, #70)
+- **Metrics on a separate listener bound to localhost** (`127.0.0.1:9090` by default) — never co-located with the public API port. Run a Prometheus sidecar or override `STROMBOLI_METRICS_ADDRESS` if you need cross-pod scraping. (#46, #66)
+
+### Fixed
+
+- Dev compose now uses a named volume for sessions (was a bind mount that dropped state across `compose down`). (#50, #69)
+- `.dockerignore` slims the build context. (#51, #68)
+
+### Infra
+
+- Kubernetes manifests under `deployments/kubernetes/` (namespace, ConfigMap, Secret example, Deployment, Service, Kustomization).
+- Prometheus alert rules under `deployments/grafana/`.
+- Dev image notes in `deployments/`. (#53, #54, #55, #71)
+- CI pipeline for lint, tests, and Docker build. (#44, #63)
+
 #### Lifecycle Hooks
 - **OnCreateCommand**: Run commands once when session is first created (e.g., `pip install`)
 - **PostCreate**: Run commands after OnCreateCommand completes (e.g., build steps)

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -99,9 +99,9 @@ STROMBOLI_RATE_LIMIT_BURST=20
 
 | Variable | Default | Description |
 |---|---|---|
-| `STROMBOLI_AUTH_ENABLED` | `false` | Enable authentication |
+| `STROMBOLI_AUTH_ENABLED` | `true` | Enable authentication. Server fails fast at startup if no JWT secret is configured (or it's a placeholder). Disable only for local dev. |
 | `STROMBOLI_API_TOKENS` | (none) | Static API tokens (comma-separated) |
-| `STROMBOLI_JWT_SECRET` | (none) | JWT signing secret |
+| `STROMBOLI_JWT_SECRET` | (none) | JWT signing secret (required when auth is enabled — minimum 32 chars, no placeholders) |
 | `STROMBOLI_JWT_EXPIRY` | `24h` | Access token lifetime |
 | `STROMBOLI_JWT_REFRESH_EXPIRY` | `168h` | Refresh token lifetime |
 
@@ -124,10 +124,14 @@ STROMBOLI_RATE_LIMIT_BURST=20
 
 | Variable | Default | Description |
 |---|---|---|
+| `STROMBOLI_LOG_FORMAT` | `json` | Log encoder (`json` for log aggregators, `text` for humans) |
+| `STROMBOLI_LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
 | `STROMBOLI_TRACING_ENABLED` | `false` | Enable OpenTelemetry tracing |
 | `STROMBOLI_TRACING_ENDPOINT` | `localhost:4317` | OTLP gRPC endpoint |
 | `STROMBOLI_TRACING_SERVICE_NAME` | `stromboli` | Service name in traces |
-| `STROMBOLI_TRACING_INSECURE` | `true` | Use insecure connection |
+| `STROMBOLI_TRACING_INSECURE` | `false` | Disable TLS for the OTLP exporter (insecure — dev only) |
+| `STROMBOLI_METRICS_ENABLED` | `true` | Expose Prometheus metrics on a separate listener |
+| `STROMBOLI_METRICS_ADDRESS` | `127.0.0.1:9090` | Metrics listener bind address. Defaults to localhost so a forgotten port doesn't expose metrics publicly — front it with a sidecar or reverse proxy if you need cross-namespace scraping. |
 | `STROMBOLI_TOKEN_CACHE_ENABLED` | `true` | Cache credentials in memory |
 | `STROMBOLI_TOKEN_CACHE_TTL` | `5m` | Cache TTL |
 
@@ -175,17 +179,23 @@ resources:
   timeout: "30m"
 
 auth:
-  enabled: false
+  enabled: true   # default; server fails fast without a real JWT secret
 
 jwt:
-  secret: ""
+  secret: ""              # set via STROMBOLI_JWT_SECRET (≥32 chars, no placeholders)
   access_expiry: "24h"
   refresh_expiry: "168h"
 
 rate_limit:
-  enabled: false
+  enabled: false  # opt-in
   rate: 10
   burst: 20
+
+tracing:
+  enabled: false
+  service_name: "stromboli"
+  endpoint: "localhost:4317"
+  insecure: false   # TLS by default — set to true only for local dev collectors
 
 jobs:
   cleanup_ttl: "1h"

--- a/stromboli.example.yaml
+++ b/stromboli.example.yaml
@@ -17,7 +17,7 @@ server:
 agent:
   image: "stromboli-agent"  # Container image to use (without tag)
   image_tag: "latest"  # Container image tag (pin to specific version for production, e.g., "v1.0.0")
-  secrets_file: ".claude-secrets"  # Path to Claude API secrets file
+  credentials_file: ".claude-secrets"  # Path to Claude credentials JSON (~/.claude/.credentials.json by default)
   sessions_dir: ".stromboli/sessions"  # Directory for session data
   token_cache:
     enabled: true  # Enable token caching (reduces file reads)
@@ -31,7 +31,8 @@ resources:
 
 # Authentication Configuration
 auth:
-  enabled: false  # Enable authentication (recommended for production)
+  enabled: true   # Auth is on by default. Server fails fast at startup without a
+                  # real JWT secret — disable only for local dev/testing.
   valid_tokens:   # List of valid API tokens (legacy, use JWT in production)
     # - "token1"
     # - "token2"
@@ -58,7 +59,7 @@ tracing:
   enabled: false             # Enable distributed tracing
   service_name: "stromboli"  # Service name in traces
   endpoint: "localhost:4317" # OTLP collector endpoint (gRPC)
-  insecure: true             # Use insecure connection (no TLS)
+  insecure: false            # TLS by default — set to true only for local dev collectors
 
 # Compose Environment Configuration
 # Enables running Claude agents in multi-service environments defined by Docker/Podman Compose files
@@ -105,7 +106,7 @@ compose:
 # agent:
 #   image: "ghcr.io/your-org/stromboli-agent"
 #   image_tag: "v1.0.0"
-#   secrets_file: "/secrets/claude-api-key"
+#   credentials_file: "/secrets/claude-api-key"
 #   sessions_dir: "/data/sessions"
 #   token_cache:
 #     enabled: true


### PR DESCRIPTION
## Summary

Closes the doc-drift Critical findings from the recent audit. Pure documentation + a single ConfigMap line, no code changes.

- **Auth defaults aligned with reality.** README and `configuration.md` claimed `STROMBOLI_AUTH_ENABLED` defaulted to `false`; the code has set it to `true` since #45/#64. Updated to `true` and explained the fail-fast JWT-secret check operators hit on first start.
- **Tracing default aligned.** `STROMBOLI_TRACING_INSECURE` was documented as `true` but defaults to `false` (TLS) since #49/#70. Fixed in `configuration.md` and the YAML samples.
- **Persistent Agents documented.** Six `/agents/*` endpoints from #60/#73 weren't mentioned anywhere in `endpoints.md`. Added a full section with status state machine, error codes, SSE event types.
- **`RunResponse.usage` documented.** Token totals + estimated USD cost from #56/#72 are now in the response example, plus a notes block on `claude.effort` (#74/#84), `prompt_caching_ttl`/`bedrock_service_tier`/`enable_powershell_tool` (#76/#77/#81/#85).
- **Sessions list title surfaced** (#83/#86) — `GET /sessions` returns `{id, title}` records, not bare strings.
- **Single-message endpoint** `GET /sessions/:id/messages/:message_id` now documented.
- **Changelog catch-up.** Filled in ~20 commits' worth of Unreleased entries.
- **`stromboli.example.yaml` typo fixed** — `secrets_file:` was a key the loader never binds; the actual key is `credentials_file:`. Anyone copying the example silently lost their credential path.
- **`deployments/kubernetes/configmap.yaml`** binds metrics to `127.0.0.1:9090` (matching the code default and PR #46/#66 intent). The previous `0.0.0.0:9090` undid the localhost binding inside every pod that used the manifest. Comment now explains the sidecar / NetworkPolicy escape hatch for genuine cross-pod scraping.

## Test plan

- [ ] `mkdocs serve` locally and skim the changed pages
- [ ] Verify `endpoints.md` table-of-contents anchors still resolve
- [ ] Confirm `stromboli.example.yaml` parses without warnings on a fresh checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)