### PR TITLE
fix: error wrapping, watchIdle cancellation, X-RateLimit-Remaining semantics

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -79,6 +79,12 @@ type Agent struct {
 	currentTurnID  string
 	exitErr        error
 
+	// done is closed exactly once when the agent transitions to StatusExited.
+	// Background goroutines (watchIdle) select on it to exit promptly instead
+	// of waiting for their next tick.
+	done     chan struct{}
+	doneOnce sync.Once
+
 	// Process plumbing.
 	process agentProcess
 

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -86,6 +86,7 @@ func (m *Manager) Create(ctx context.Context, req CreateRequest, build ArgvBuild
 		lastActivityAt: now,
 		idleTimeout:    idleTimeout,
 		subscribers:    map[int]chan Event{},
+		done:           make(chan struct{}),
 	}
 
 	// Buffered: stdout reader runs ahead of the dispatcher; the buffer absorbs
@@ -327,19 +328,27 @@ func (a *Agent) dispatch(sink <-chan string) {
 func (a *Agent) watchIdle(m *Manager) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
-	for range ticker.C {
-		a.mu.Lock()
-		if a.status == StatusExited {
+	for {
+		select {
+		case <-a.done:
+			// Agent already exited (clean stop, crash, idle timeout from a
+			// previous tick). Bail immediately instead of holding a goroutine
+			// alive for up to 30s waiting for the next tick.
+			return
+		case <-ticker.C:
+			a.mu.Lock()
+			if a.status == StatusExited {
+				a.mu.Unlock()
+				return
+			}
+			idle := time.Since(a.lastActivityAt)
+			timeout := a.idleTimeout
 			a.mu.Unlock()
-			return
-		}
-		idle := time.Since(a.lastActivityAt)
-		timeout := a.idleTimeout
-		a.mu.Unlock()
-		if idle >= timeout {
-			a.fanout(Event{Type: "exited", Error: ErrIdleTimedOut.Error(), At: time.Now()})
-			_ = m.Stop(a.ID)
-			return
+			if idle >= timeout {
+				a.fanout(Event{Type: "exited", Error: ErrIdleTimedOut.Error(), At: time.Now()})
+				_ = m.Stop(a.ID)
+				return
+			}
 		}
 	}
 }
@@ -347,7 +356,7 @@ func (a *Agent) watchIdle(m *Manager) {
 func (a *Agent) fanout(ev Event) {
 	a.subsMu.Lock()
 	defer a.subsMu.Unlock()
-	for id, ch := range a.subscribers {
+	for _, ch := range a.subscribers {
 		select {
 		case ch <- ev:
 		default:
@@ -361,7 +370,6 @@ func (a *Agent) fanout(ev Event) {
 			default:
 				// Still full somehow — give up rather than block. Subscriber
 				// will see a gap; that's the contract.
-				_ = id
 			}
 		}
 	}
@@ -404,6 +412,11 @@ func (a *Agent) markExited(err error) {
 	a.status = StatusExited
 	a.exitErr = err
 	a.mu.Unlock()
+
+	// Signal background goroutines (watchIdle) that they should exit. Done
+	// before the fan-out so the next tick after this call sees the channel
+	// already closed.
+	a.doneOnce.Do(func() { close(a.done) })
 
 	errStr := ""
 	if err != nil {

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -136,8 +136,11 @@ func RateLimitMiddleware(config RateLimitConfig) gin.HandlerFunc {
 			return
 		}
 
-		// Calculate remaining requests
-		remaining := l.Burst() - int(l.Tokens())
+		// Calculate remaining requests as the number of tokens currently in
+		// the bucket, floored at zero. The previous formula `Burst()-Tokens()`
+		// reported the *consumed* count, which is the inverse of what
+		// X-RateLimit-Remaining is supposed to convey to the client.
+		remaining := int(l.Tokens())
 		if remaining < 0 {
 			remaining = 0
 		}

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -179,6 +180,43 @@ func TestRateLimitDisabled(t *testing.T) {
 		router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 	}
+}
+
+func TestRateLimit_RemainingHeaderReportsAvailableTokens(t *testing.T) {
+	// X-RateLimit-Remaining is supposed to tell the client how many more
+	// requests they can make right now — not how many they've already used.
+	// Burst=5: after the first allowed request, 4 tokens remain.
+	gin.SetMode(gin.TestMode)
+
+	cfg := RateLimitConfig{
+		Enabled: true,
+		Rate:    1, // slow refill so we observe the bucket draining as we burst
+		Period:  time.Second,
+		Burst:   5,
+	}
+
+	router := gin.New()
+	router.Use(RateLimitMiddleware(cfg))
+	router.GET("/", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{}) })
+
+	// Make 3 quick requests against the same client and assert remaining
+	// counts down monotonically toward zero (not upward toward Burst).
+	var remainings []int
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = "192.0.2.10:1234"
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		var r int
+		_, err := fmt.Sscanf(w.Header().Get("X-RateLimit-Remaining"), "%d", &r)
+		assert.NoError(t, err)
+		remainings = append(remainings, r)
+	}
+
+	assert.LessOrEqual(t, remainings[0], 4, "first request: at most burst-1 left")
+	assert.LessOrEqual(t, remainings[1], remainings[0], "remaining must not increase between bursts")
+	assert.LessOrEqual(t, remainings[2], remainings[1], "remaining must not increase between bursts")
 }
 
 func TestRateLimitErrorResponse(t *testing.T) {

--- a/internal/compose/validator.go
+++ b/internal/compose/validator.go
@@ -34,30 +34,24 @@ func NewFileValidator(cfg Config) *FileValidator {
 // Validate checks if a compose file is valid and compliant with security settings.
 // It returns nil if the file is valid, or an error describing the issue.
 func (v *FileValidator) Validate(path string) error {
-	// Validate path
 	if err := v.validatePath(path); err != nil {
-		return err
+		return fmt.Errorf("compose: validate path %q: %w", path, err)
 	}
-
-	// Parse and validate compose file contents
 	if err := v.validateContents(path); err != nil {
-		return err
+		return fmt.Errorf("compose: validate contents of %q: %w", path, err)
 	}
-
 	return nil
 }
 
 // ValidateWithService validates a compose file and checks that the specified service exists
 func (v *FileValidator) ValidateWithService(path, service string) error {
-	// First validate the file itself
 	if err := v.Validate(path); err != nil {
-		return err
+		return err // already wrapped by Validate
 	}
 
-	// Then check the service exists
 	compose, err := v.parseComposeFile(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("compose: parse %q for service lookup: %w", path, err)
 	}
 
 	if _, ok := compose.Services[service]; !ok {

--- a/internal/runner/cleanup.go
+++ b/internal/runner/cleanup.go
@@ -58,7 +58,7 @@ func CleanupOrphanedContainers(ctx context.Context) error {
 		if strings.Contains(err.Error(), "no such") {
 			return nil
 		}
-		return err
+		return fmt.Errorf("runner: list orphaned containers via podman ps: %w", err)
 	}
 
 	containers := strings.Split(strings.TrimSpace(string(output)), "\n")
@@ -103,7 +103,7 @@ func CleanupStaleContainers(ctx context.Context, maxAge time.Duration) error {
 	cmd := exec.CommandContext(ctx, "podman", "ps", "--filter", "name="+ContainerNamePrefix, "--format", "{{.Names}}\t{{.RunningFor}}")
 	output, err := cmd.Output()
 	if err != nil {
-		return err
+		return fmt.Errorf("runner: list stale containers via podman ps: %w", err)
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(output)), "\n")

--- a/internal/secrets/registry.go
+++ b/internal/secrets/registry.go
@@ -111,7 +111,7 @@ func NewRegistry(executor Executor) *Registry {
 // Returns validation errors if the name contains invalid characters or exceeds length limits.
 func (r *Registry) Create(ctx context.Context, name, value string) error {
 	if err := validateName(name); err != nil {
-		return err
+		return fmt.Errorf("secrets: create %q: %w", name, err)
 	}
 	if value == "" {
 		return fmt.Errorf("%w: secret value cannot be empty", ErrValidation)


### PR DESCRIPTION
## Summary

Closes the High / Medium / Nit code-quality findings from the audit.

### Error wrapping (CLAUDE.md says always wrap with %w + context)

- \`compose/validator.go\` \`Validate\` / \`ValidateWithService\` were returning raw \`err\` from the path/content sub-validators. Now wrapped with the path being validated.
- \`runner/cleanup.go\` \`CleanupOrphanedContainers\` / \`CleanupStaleContainers\` returned raw \`cmd.Output()\` errors — callers couldn't tell which podman invocation failed. Wrapped with the operation name.
- \`secrets/registry.go\` \`Create\` returned the bare \`validateName(name)\` error. Wrapped with the operation context (which secret was being created).

### \`watchIdle\` exits promptly on agent shutdown

Previously the 30 s ticker was the only wake-up signal: \`markExited\` set \`status = StatusExited\` but \`watchIdle\` only checked it on the next tick, holding the goroutine alive for up to 30 s past process death. Now selects on a per-agent \`done\` channel that \`markExited\` closes (via \`sync.Once\`), so the goroutine exits within microseconds of state-change.

### \`X-RateLimit-Remaining\` reports available, not consumed

The formula was \`Burst() - Tokens()\`, which is the count of *spent* tokens — the opposite of what \`X-RateLimit-Remaining\` communicates. Replaced with \`int(l.Tokens())\` floored at zero. Added a regression test that bursts three requests against the same client and asserts the header decreases monotonically.

### Drop a stray \`_ = id\` in fanout

Artefact of \`for id, ch := range a.subscribers\` where only \`ch\` was used in the body. Switched to \`for _, ch := range\`.

## Test plan

- [x] \`go test ./...\` passes locally (golang:1.26 in podman)
- [ ] CI green
- [ ] Manual: hit /run with rate limiting on, observe \`X-RateLimit-Remaining\` decreasing across consecutive requests instead of climbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)