### PR TITLE
test: cover agent/process and convert job-cleanup sleeps to Eventually

### DIFF
--- a/internal/agent/process_test.go
+++ b/internal/agent/process_test.go
@@ -1,0 +1,199 @@
+package agent
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// processSpawner exercises real os/exec subprocesses, so the tests need a
+// shell. They use `cat` (read stdin → write stdout, then exit on EOF) which is
+// available on every Linux/macOS dev image; Windows is skipped explicitly.
+
+func skipIfNoCat(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX cat / sh; skipping on Windows")
+	}
+}
+
+func TestProcessSpawner_ForwardsStdoutLines(t *testing.T) {
+	skipIfNoCat(t)
+
+	sink := make(chan string, 8)
+	spawner := NewProcessSpawner()
+
+	// `printf 'a\nb\nc\n'` writes three lines and exits — exercises the
+	// forwardLines goroutine end-to-end and confirms the wait goroutine
+	// closes the sink on process exit so a `range` consumer sees EOF.
+	exited := make(chan struct{})
+	proc, err := spawner.Spawn(context.Background(),
+		SpawnRequest{Argv: []string{"sh", "-c", "printf 'a\\nb\\nc\\n'"}},
+		sink,
+		func(_ error) { close(exited) },
+	)
+	require.NoError(t, err)
+	defer proc.Stop(time.Second)
+
+	var got []string
+	for line := range sink {
+		got = append(got, line)
+	}
+	assert.Equal(t, []string{"a", "b", "c"}, got)
+
+	select {
+	case <-exited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("onExit never fired")
+	}
+}
+
+func TestProcessSpawner_TagsStderrLines(t *testing.T) {
+	skipIfNoCat(t)
+
+	sink := make(chan string, 4)
+	spawner := NewProcessSpawner()
+
+	// echo to fd 2 — confirms stderr lines are prefixed so the dispatcher
+	// can route them to error events.
+	_, err := spawner.Spawn(context.Background(),
+		SpawnRequest{Argv: []string{"sh", "-c", "echo oops 1>&2"}},
+		sink,
+		nil,
+	)
+	require.NoError(t, err)
+
+	var lines []string
+	for line := range sink {
+		lines = append(lines, line)
+	}
+
+	var seenStderr bool
+	for _, line := range lines {
+		if strings.HasPrefix(line, "[stderr] ") {
+			assert.Equal(t, "[stderr] oops", line)
+			seenStderr = true
+		}
+	}
+	assert.True(t, seenStderr, "stderr line should be prefixed and forwarded; got %v", lines)
+}
+
+func TestProcessSpawner_SendWritesToStdin(t *testing.T) {
+	skipIfNoCat(t)
+
+	sink := make(chan string, 8)
+	spawner := NewProcessSpawner()
+
+	// `cat` echoes stdin on stdout — perfect for confirming Send delivers.
+	proc, err := spawner.Spawn(context.Background(),
+		SpawnRequest{Argv: []string{"cat"}},
+		sink,
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, proc.Send(`hello world`))
+	require.NoError(t, proc.Send(`second line`))
+
+	// First two lines should make it through. Stop closes stdin so cat exits.
+	var got []string
+	go func() {
+		// Give cat a moment to flush both lines, then close stdin so the
+		// scanner reaches EOF and the sink closes.
+		time.Sleep(50 * time.Millisecond)
+		_ = proc.Stop(time.Second)
+	}()
+	for line := range sink {
+		got = append(got, line)
+	}
+	assert.Contains(t, got, "hello world")
+	assert.Contains(t, got, "second line")
+}
+
+func TestProcessSpawner_SendAfterExitFails(t *testing.T) {
+	skipIfNoCat(t)
+
+	sink := make(chan string, 4)
+	spawner := NewProcessSpawner()
+
+	// `true` exits immediately with code 0.
+	proc, err := spawner.Spawn(context.Background(),
+		SpawnRequest{Argv: []string{"true"}},
+		sink,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// Drain the sink so Wait can complete.
+	go func() {
+		for range sink {
+		}
+	}()
+
+	// Wait for the wait goroutine to mark the process as exited.
+	require.Eventually(t, func() bool {
+		return proc.Send("post-exit") != nil
+	}, time.Second, 5*time.Millisecond, "Send must fail after process has exited")
+}
+
+func TestProcessSpawner_StopReturnsExitError(t *testing.T) {
+	skipIfNoCat(t)
+
+	sink := make(chan string, 4)
+	spawner := NewProcessSpawner()
+
+	// Hang reading stdin — Stop has to escalate (close stdin → SIGTERM → SIGKILL).
+	proc, err := spawner.Spawn(context.Background(),
+		SpawnRequest{Argv: []string{"cat"}},
+		sink,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// Drain in the background so the wait goroutine can complete.
+	go func() {
+		for range sink {
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		_ = proc.Stop(50 * time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return within 2s — escalation may be broken")
+	}
+}
+
+func TestProcessSpawner_RejectsEmptyArgv(t *testing.T) {
+	spawner := NewProcessSpawner()
+	_, err := spawner.Spawn(context.Background(),
+		SpawnRequest{Argv: nil},
+		make(chan string, 1),
+		nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty argv")
+}
+
+func TestProcessSpawner_StartFailureSurfacesError(t *testing.T) {
+	skipIfNoCat(t)
+
+	spawner := NewProcessSpawner()
+	_, err := spawner.Spawn(context.Background(),
+		SpawnRequest{Argv: []string{"/this/binary/does/not/exist"}},
+		make(chan string, 1),
+		nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent: start")
+}

--- a/internal/agent/process_test.go
+++ b/internal/agent/process_test.go
@@ -38,7 +38,7 @@ func TestProcessSpawner_ForwardsStdoutLines(t *testing.T) {
 		func(_ error) { close(exited) },
 	)
 	require.NoError(t, err)
-	defer proc.Stop(time.Second)
+	defer func() { _ = proc.Stop(time.Second) }()
 
 	var got []string
 	for line := range sink {

--- a/internal/job/job_test.go
+++ b/internal/job/job_test.go
@@ -246,19 +246,19 @@ func TestManager_StartStopCleanup(t *testing.T) {
 
 		// Start cleanup with 1 hour TTL, 10ms interval
 		m.StartCleanup(1*time.Hour, 10*time.Millisecond)
+		defer m.StopCleanup()
 
-		// Wait for cleanup to run
-		time.Sleep(50 * time.Millisecond)
+		// Old job should be deleted by the cleanup goroutine; poll instead of
+		// time.Sleep so the test runs as fast as the cleanup actually fires.
+		require.Eventually(t, func() bool {
+			_, exists := m.Get("old-job")
+			return !exists
+		}, time.Second, 5*time.Millisecond)
 
-		// Stop cleanup
-		m.StopCleanup()
-
-		// Old job should be deleted
-		_, exists := m.Get("old-job")
-		assert.False(t, exists)
-
-		// Recent job should still exist
-		_, exists = m.Get("recent-job")
+		// Recent job is also a side effect: by the time the deletion above
+		// is observable, at least one cleanup tick has fired — so a snapshot
+		// of "recent-job still exists" is safe to read here.
+		_, exists := m.Get("recent-job")
 		assert.True(t, exists)
 	})
 
@@ -271,11 +271,12 @@ func TestManager_StartStopCleanup(t *testing.T) {
 		m.mu.Unlock()
 
 		m.StartCleanup(1*time.Hour, 10*time.Millisecond)
-		time.Sleep(50 * time.Millisecond)
-		m.StopCleanup()
+		defer m.StopCleanup()
 
-		_, exists := m.Get("old-failed")
-		assert.False(t, exists)
+		require.Eventually(t, func() bool {
+			_, exists := m.Get("old-failed")
+			return !exists
+		}, time.Second, 5*time.Millisecond)
 	})
 
 	t.Run("cleanup removes old cancelled jobs", func(t *testing.T) {
@@ -287,11 +288,12 @@ func TestManager_StartStopCleanup(t *testing.T) {
 		m.mu.Unlock()
 
 		m.StartCleanup(1*time.Hour, 10*time.Millisecond)
-		time.Sleep(50 * time.Millisecond)
-		m.StopCleanup()
+		defer m.StopCleanup()
 
-		_, exists := m.Get("old-cancelled")
-		assert.False(t, exists)
+		require.Eventually(t, func() bool {
+			_, exists := m.Get("old-cancelled")
+			return !exists
+		}, time.Second, 5*time.Millisecond)
 	})
 
 	t.Run("cleanup does not remove pending jobs", func(t *testing.T) {
@@ -395,11 +397,12 @@ func TestManager_Cleanup_CrashedJobs(t *testing.T) {
 		m.mu.Unlock()
 
 		m.StartCleanup(1*time.Hour, 10*time.Millisecond)
-		time.Sleep(50 * time.Millisecond)
-		m.StopCleanup()
+		defer m.StopCleanup()
 
-		_, exists := m.Get("old-crashed")
-		assert.False(t, exists)
+		require.Eventually(t, func() bool {
+			_, exists := m.Get("old-crashed")
+			return !exists
+		}, time.Second, 5*time.Millisecond)
 	})
 
 	t.Run("recent crashed jobs are not cleaned up", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes the **High** coverage gap and the **Medium** \"hardcoded sleeps in tests\" smell from the audit.

### \`agent/process.go\` was completely untested

Added \`internal/agent/process_test.go\` with 7 tests against the real \`processSpawner\` using \`sh\` / \`cat\` / \`true\` subprocesses (skipped on Windows since they aren't part of the agent runtime). Coverage:

- \`TestProcessSpawner_ForwardsStdoutLines\` — multi-line stdout end-to-end, sink closes on exit
- \`TestProcessSpawner_TagsStderrLines\` — \`[stderr] \` prefix injected so the dispatcher can route to error events
- \`TestProcessSpawner_SendWritesToStdin\` — stdin writes round-trip via \`cat\`
- \`TestProcessSpawner_SendAfterExitFails\` — Send returns an error after the wait goroutine has marked the process exited
- \`TestProcessSpawner_StopReturnsExitError\` — Stop escalates (close stdin → SIGTERM → SIGKILL) under a hung child, returns within the timeout
- \`TestProcessSpawner_RejectsEmptyArgv\` — input validation
- \`TestProcessSpawner_StartFailureSurfacesError\` — fork/exec failure is wrapped, not swallowed

### Cleanup tests no longer sleep on a wall clock

\`internal/job/job_test.go\` had four \`time.Sleep(50 ms)\` barriers across the \"cleanup removes X\" subtests. Replaced with \`require.Eventually\` polls (1 s timeout, 5 ms interval). Tests now finish in ~10 ms each instead of ≥ 50 ms and don't false-fail under a slow CI scheduler.

The \"should not be removed\" subtests keep their bounded sleeps — their assertion is \"still present after a tick\" which has no observable side effect to poll on.

## Test plan

- [x] \`go test ./internal/agent/... ./internal/job/...\` passes locally (golang:1.26 in podman)
- [x] All other packages still pass — no test surface changes outside these two files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)