### PR TITLE
fix(agent): tolerate oversized stdout lines, emit truncation marker

### DIFF
--- a/internal/agent/forward_lines_test.go
+++ b/internal/agent/forward_lines_test.go
@@ -1,0 +1,122 @@
+package agent
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestForwardLines_TruncatesOversizedLine confirms that a single line larger
+// than maxAgentLineBytes does not deadlock the reader: forwardLines emits a
+// truncation marker for the over-budget line and keeps reading the next one.
+//
+// Without this guard, a giant tool-result line caused bufio.Scanner to
+// permanently fail, the OS pipe filled up, Claude's stdout write blocked, and
+// cmd.Wait() hung forever.
+func TestForwardLines_TruncatesOversizedLine(t *testing.T) {
+	// Two lines: the first is comfortably over the cap; the second is small
+	// and proves the reader keeps going after the overflow.
+	pr, pw := io.Pipe()
+	sink := make(chan string, 4)
+
+	// Close the sink once forwardLines returns so the test's range loop
+	// terminates. In production, Spawn's wait goroutine does this after
+	// pipesDone.Wait — here we mimic that contract directly.
+	done := make(chan struct{})
+	go func() {
+		forwardLines(pr, sink, "")
+		close(sink)
+		close(done)
+	}()
+
+	go func() {
+		// 12 MiB of 'x', then \n, then a normal line, then EOF.
+		// Stream the giant blob in 1 MiB chunks so the reader and writer
+		// share progress instead of buffering 12 MiB on the heap at once.
+		chunk := strings.Repeat("x", 1<<20)
+		for i := 0; i < 12; i++ {
+			_, err := io.WriteString(pw, chunk)
+			require.NoError(t, err)
+		}
+		_, err := io.WriteString(pw, "\nfollow-up\n")
+		require.NoError(t, err)
+		_ = pw.Close()
+	}()
+
+	got := make([]string, 0, 2)
+	for line := range sink {
+		got = append(got, line)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("forwardLines did not return — overflow handling is deadlocking")
+	}
+
+	require.Len(t, got, 2, "expected one marker line + one follow-up line, got %v", got)
+	assert.Contains(t, got[0], "[stromboli: line truncated")
+	assert.Equal(t, "follow-up", got[1])
+}
+
+// TestForwardLines_ForwardsNormalLines is a sanity check that the new
+// implementation didn't regress the happy path.
+func TestForwardLines_ForwardsNormalLines(t *testing.T) {
+	pr, pw := io.Pipe()
+	sink := make(chan string, 8)
+
+	done := make(chan struct{})
+	go func() {
+		forwardLines(pr, sink, "[p] ")
+		close(sink)
+		close(done)
+	}()
+
+	go func() {
+		_, _ = io.WriteString(pw, "alpha\nbeta\n\ngamma\n")
+		_ = pw.Close()
+	}()
+
+	var got []string
+	for line := range sink {
+		got = append(got, line)
+	}
+	<-done
+
+	// We deliberately preserve the empty line between beta and gamma —
+	// stream-json sometimes uses blank separators and dropping them silently
+	// would break downstream parsers.
+	assert.Equal(t, []string{"[p] alpha", "[p] beta", "[p] ", "[p] gamma"}, got)
+}
+
+// TestForwardLines_HandlesNoTrailingNewline checks the corner case where a
+// process exits without flushing a final newline. The buffered partial line
+// should still be emitted (don't silently drop a meaningful payload).
+func TestForwardLines_HandlesNoTrailingNewline(t *testing.T) {
+	pr, pw := io.Pipe()
+	sink := make(chan string, 2)
+
+	done := make(chan struct{})
+	go func() {
+		forwardLines(pr, sink, "")
+		close(sink)
+		close(done)
+	}()
+
+	go func() {
+		_, _ = io.WriteString(pw, "first\nlast-without-newline")
+		_ = pw.Close()
+	}()
+
+	var got []string
+	for line := range sink {
+		got = append(got, line)
+	}
+	<-done
+
+	assert.Equal(t, []string{"first", "last-without-newline"}, got)
+}

--- a/internal/agent/process.go
+++ b/internal/agent/process.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -119,18 +120,64 @@ func (s *processSpawner) Spawn(ctx context.Context, req SpawnRequest, lineSink c
 	return p, nil
 }
 
+// maxAgentLineBytes caps the size of a single forwarded line. Anything beyond
+// this is dropped with a marker emitted in its place — see forwardLines.
+const maxAgentLineBytes = 10 << 20 // 10 MiB
+
 func forwardLines(r io.Reader, sink chan<- string, prefix string) {
-	scanner := bufio.NewScanner(r)
-	// Stream-json output can have very long lines (full tool results inline).
-	scanner.Buffer(make([]byte, 0, 1<<16), 10<<20) // up to 10 MiB / line.
-	for scanner.Scan() {
-		// Block-send: the buffered sink (256 entries) absorbs bursts. If the
-		// dispatcher is so far behind that the buffer fills, applying back-
-		// pressure to Claude's stdout writer is the right move — it's far
-		// better than dropping events we'd otherwise have to silently lose.
-		sink <- prefix + scanner.Text()
+	// We use bufio.Reader rather than bufio.Scanner because Scanner permanently
+	// fails on the first line that exceeds its buffer cap. With Reader.ReadLine
+	// we can detect overflow per line, drain the rest of that line, and keep
+	// reading subsequent lines — so one giant tool result doesn't deadlock the
+	// agent (the OS pipe would otherwise fill up and block Claude's stdout
+	// write, hanging cmd.Wait forever).
+	br := bufio.NewReaderSize(r, 1<<16)
+	var (
+		buf       bytes.Buffer
+		truncated bool
+	)
+	for {
+		chunk, isPrefix, err := br.ReadLine()
+		if len(chunk) > 0 {
+			if !truncated {
+				if buf.Len()+len(chunk) <= maxAgentLineBytes {
+					buf.Write(chunk)
+				} else {
+					// First overflow chunk for this line — flip the flag and
+					// drop both this and any subsequent chunks until the line
+					// terminates. Dropping (rather than appending up to the
+					// cap) avoids producing a confusing half-line that callers
+					// might try to JSON-parse.
+					truncated = true
+				}
+			}
+		}
+		if !isPrefix {
+			// End of line reached (or end of stream with a trailing line).
+			// Block-send: the buffered sink (256 entries) absorbs bursts. If
+			// the dispatcher is so far behind that the buffer fills, applying
+			// back-pressure to Claude's stdout writer is the right move — it's
+			// far better than dropping events we'd otherwise have to silently
+			// lose.
+			if truncated {
+				sink <- prefix + fmt.Sprintf("[stromboli: line truncated, exceeded %d bytes]", maxAgentLineBytes)
+			} else if buf.Len() > 0 || err == nil {
+				// Emit even an empty line when err==nil (a bare "\n") so we
+				// don't silently drop intentional blank separators. On err
+				// (typically io.EOF), don't emit a phantom empty line.
+				sink <- prefix + buf.String()
+			}
+			buf.Reset()
+			truncated = false
+		}
+		if err != nil {
+			// io.EOF is the normal exit path when the pipe closes. Other
+			// errors (e.g. unexpected EOF on a killed process) are also a
+			// signal to stop reading — the wait goroutine handles surfacing
+			// the underlying cause.
+			return
+		}
 	}
-	// Scanner errors after process exit (closed pipe) are expected — ignore.
 }
 
 func (p *realProcess) Send(line string) error {


### PR DESCRIPTION
## Summary

Closes the liveness bug found while re-defending the audit's (incorrect) "ctx cancellation goroutine leak" claim against \`agent/process.go\`. The audit was wrong about cancellation — \`exec.CommandContext\` SIGKILLs on ctx-done, which closes pipes and unblocks all goroutines — but adjacent to that claim is a real bug:

\`forwardLines\` used \`bufio.Scanner\` with a 10 MiB cap. A single line above the cap made Scanner permanently fail. With no reader draining the OS pipe, Claude's next stdout write **blocked**. \`cmd.Wait\` never returned because the process was alive (just stuck). Sink never closed, subscribers saw no events, the agent appeared frozen.

## The fix

Replaced \`bufio.Scanner\` with \`bufio.Reader.ReadLine\` which streams the current line in chunks via \`isPrefix\`. Per-line state machine:

1. Accumulate chunks into a buffer up to \`maxAgentLineBytes\` (10 MiB)
2. On the first chunk that would exceed the cap, set \`truncated=true\` and drop subsequent chunks for *this* line
3. When \`isPrefix=false\` (line terminator reached), emit either the buffered content or a single marker:

   \`\`\`
   [stromboli: line truncated, exceeded 10485760 bytes]
   \`\`\`

4. Next line is processed normally — overflow doesn't poison the reader.

Empty lines (\`"\n"\`) and trailing partial lines without a final newline are preserved. Stream-json sometimes uses blank separators, and a truncated final line may still carry meaningful payload.

## Why option 3 (truncate-and-emit) over the alternatives

- **Drop the cap entirely**: 12 MiB tool results buffer fully in RAM, OOM risk on a busy server.
- **Drain on overflow silently**: callers see the agent pause with no explanation; no marker means the line is gone forever from their perspective.
- **Truncate-and-emit (chosen)**: bounded memory, the subscriber sees a structured marker they can log/alert on.

## Test plan

- [x] \`go test ./internal/agent/...\` passes locally (golang:1.26 in podman)
- [x] \`go test ./...\` passes — no regressions in any other package
- [x] New regression test pumps 12 MiB followed by a small line; asserts the marker fires, the follow-up line survives, and \`forwardLines\` returns within 5 s (was deadlocking before the fix)
- [ ] CI green
- [ ] Manual: send a request that returns a giant tool result via a real Claude run, confirm the agent doesn't freeze and the marker shows up in \`/agents/:id/stream\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)