### PR TITLE
release: cut [0.5.0-alpha] changelog section

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@ All notable changes to Stromboli will be documented here.
 
 ## [Unreleased]
 
+_(empty — add new entries here as PRs land)_
+
+---
+
+## [0.5.0-alpha] - 2026-05-01
+
 ### Added
 
 #### Persistent Agents


### PR DESCRIPTION
## Summary

Release-prep PR for **v0.5.0-alpha**. Closes the Unreleased section into a dated \`[0.5.0-alpha] - 2026-05-01\` section and adds a fresh empty Unreleased section on top for future work.

After this lands, push the \`v0.5.0-alpha\` tag to trigger the release workflow (binaries + Docker images + GitHub release).

## Why a minor bump rather than 0.4.4

The release contains four operationally-breaking default changes that operators must read before upgrading:

- **Auth on by default** — server fails fast without a real \`STROMBOLI_JWT_SECRET\` (#45, #64)
- **Tracing TLS by default** — \`STROMBOLI_TRACING_INSECURE\` flipped to \`false\` (#49, #70)
- **Metrics bound to 127.0.0.1:9090** — no longer co-located with the public port (#46, #66)
- **Logs JSON by default** — \`STROMBOLI_LOG_FORMAT=text\` for humans (#47, #65)

Plus a substantial new feature surface: persistent agents, token usage/cost, claude.effort, env-var passthrough, session titles, webhook signing, pluggable token blacklist.

## Test plan

- [ ] \`mkdocs serve\` and verify the Changelog page renders the new section header correctly
- [ ] CI green
- [ ] After merge: \`git tag v0.5.0-alpha && git push origin v0.5.0-alpha\` triggers the Release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)