### PR TITLE
ci: drop windows/amd64 from release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
   build-binaries:
     name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
     runs-on: ubuntu-latest
+    # Windows is intentionally excluded from the release matrix. Stromboli
+    # orchestrates Podman containers and uses Unix-only syscalls (process
+    # groups via SysProcAttr.Setpgid, signal delivery via syscall.Kill) in
+    # the persistent-agent path, so a Windows binary can't link. Operators
+    # on Windows hosts run Stromboli inside a Linux container or WSL2 VM.
     strategy:
       matrix:
         include:
@@ -32,9 +37,6 @@ jobs:
           - goos: darwin
             goarch: arm64
             name: stromboli-darwin-arm64
-          - goos: windows
-            goarch: amd64
-            name: stromboli-windows-amd64.exe
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

The v0.5.0-alpha release run failed on the windows/amd64 build target. Persistent agents (#73) introduced Unix-only syscalls in \`internal/agent/process.go\`:

- \`syscall.SysProcAttr.Setpgid\` — Linux/macOS only
- \`syscall.Kill\` — Unix only

CI's lint + test jobs run on Linux so they never hit the cross-compile error. \`release.yml\`'s \`GOOS=windows\` build was the first thing to actually try and it broke the alpha tag.

## Why drop Windows entirely instead of guarding the file

Stromboli is fundamentally Linux-bound: it orchestrates Podman containers via the Podman Unix socket. Even with a Windows binary, you can't actually run it as a host — operators on Windows use WSL2 or a Linux container. Maintaining a parallel Windows process-control path (job objects, \`TerminateJobObject\`, etc.) for a target that can't actually function is negative-EV.

If someone ever wants a Windows port later, the path is:

- \`internal/agent/process_unix.go\` — current code with \`//go:build !windows\`
- \`internal/agent/process_windows.go\` — job-object-based equivalents
- restore the \`windows/amd64\` matrix entry

## Recovery plan

The \`v0.5.0-alpha\` tag was deleted (no artifacts had been published — the matrix failure short-circuited the release-create job). After this PR lands, retag and push to trigger the workflow cleanly.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: \`git tag v0.5.0-alpha && git push origin v0.5.0-alpha\` runs the release workflow with 4 matrix entries instead of 5
- [ ] Verify GitHub release page lists the 4 expected binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)