### PR TITLE
refactor(api): fully type the OpenAPI request/response bodies

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -710,8 +710,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/internal_api.JobCancelResponse"
                         }
                     },
                     "404": {
@@ -1574,6 +1573,20 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_api.JobCancelResponse": {
+            "description": "Result of a job cancel request",
+            "type": "object",
+            "properties": {
+                "cancelled": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "job_id": {
+                    "type": "string",
+                    "example": "job-abc123def456"
+                }
+            }
+        },
         "internal_api.JobListResponse": {
             "description": "List of async jobs",
             "type": "object",
@@ -1962,24 +1975,31 @@ const docTemplate = `{
             }
         },
         "stromboli_internal_agent.CreateRequest": {
+            "description": "Configuration for spawning a long-lived Claude agent",
             "type": "object",
             "properties": {
                 "claude": {
-                    "description": "Free-form Claude CLI options forwarded to the command builder.\nKept as map[string]any so we can evolve the surface without bumping the\nCreateRequest schema every time Claude adds a flag.",
-                    "type": "object",
-                    "additionalProperties": {}
+                    "description": "Claude CLI options forwarded to the command builder. Same shape as\nRunRequest.claude so callers don't have to learn two schemas — the\nfield is fully typed in OpenAPI rather than a freeform object.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/stromboli_internal_types.ClaudeOptions"
+                        }
+                    ]
                 },
                 "idle_timeout_seconds": {
                     "description": "Idle-timeout override in seconds. Zero means \"use the manager default\n(DefaultIdleTimeout)\". Negative values are rejected at parse time.",
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 1800
                 },
                 "prompt": {
                     "description": "Initial prompt sent as the first turn. Optional — callers can also\ncreate an empty agent and use /send for the first interaction.",
-                    "type": "string"
+                    "type": "string",
+                    "example": "You are an on-call assistant."
                 },
                 "workdir": {
                     "description": "Working directory inside the container.",
-                    "type": "string"
+                    "type": "string",
+                    "example": "/workspace"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -704,8 +704,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/internal_api.JobCancelResponse"
                         }
                     },
                     "404": {
@@ -1568,6 +1567,20 @@
                 }
             }
         },
+        "internal_api.JobCancelResponse": {
+            "description": "Result of a job cancel request",
+            "type": "object",
+            "properties": {
+                "cancelled": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "job_id": {
+                    "type": "string",
+                    "example": "job-abc123def456"
+                }
+            }
+        },
         "internal_api.JobListResponse": {
             "description": "List of async jobs",
             "type": "object",
@@ -1956,24 +1969,31 @@
             }
         },
         "stromboli_internal_agent.CreateRequest": {
+            "description": "Configuration for spawning a long-lived Claude agent",
             "type": "object",
             "properties": {
                 "claude": {
-                    "description": "Free-form Claude CLI options forwarded to the command builder.\nKept as map[string]any so we can evolve the surface without bumping the\nCreateRequest schema every time Claude adds a flag.",
-                    "type": "object",
-                    "additionalProperties": {}
+                    "description": "Claude CLI options forwarded to the command builder. Same shape as\nRunRequest.claude so callers don't have to learn two schemas — the\nfield is fully typed in OpenAPI rather than a freeform object.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/stromboli_internal_types.ClaudeOptions"
+                        }
+                    ]
                 },
                 "idle_timeout_seconds": {
                     "description": "Idle-timeout override in seconds. Zero means \"use the manager default\n(DefaultIdleTimeout)\". Negative values are rejected at parse time.",
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 1800
                 },
                 "prompt": {
                     "description": "Initial prompt sent as the first turn. Optional — callers can also\ncreate an empty agent and use /send for the first interaction.",
-                    "type": "string"
+                    "type": "string",
+                    "example": "You are an on-call assistant."
                 },
                 "workdir": {
                     "description": "Working directory inside the container.",
-                    "type": "string"
+                    "type": "string",
+                    "example": "/workspace"
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -241,6 +241,16 @@ definitions:
           $ref: '#/definitions/internal_api.ImageInfoResponse'
         type: array
     type: object
+  internal_api.JobCancelResponse:
+    description: Result of a job cancel request
+    properties:
+      cancelled:
+        example: true
+        type: boolean
+      job_id:
+        example: job-abc123def456
+        type: string
+    type: object
   internal_api.JobListResponse:
     description: List of async jobs
     properties:
@@ -515,26 +525,30 @@ definitions:
         type: string
     type: object
   stromboli_internal_agent.CreateRequest:
+    description: Configuration for spawning a long-lived Claude agent
     properties:
       claude:
-        additionalProperties: {}
+        allOf:
+        - $ref: '#/definitions/stromboli_internal_types.ClaudeOptions'
         description: |-
-          Free-form Claude CLI options forwarded to the command builder.
-          Kept as map[string]any so we can evolve the surface without bumping the
-          CreateRequest schema every time Claude adds a flag.
-        type: object
+          Claude CLI options forwarded to the command builder. Same shape as
+          RunRequest.claude so callers don't have to learn two schemas — the
+          field is fully typed in OpenAPI rather than a freeform object.
       idle_timeout_seconds:
         description: |-
           Idle-timeout override in seconds. Zero means "use the manager default
           (DefaultIdleTimeout)". Negative values are rejected at parse time.
+        example: 1800
         type: integer
       prompt:
         description: |-
           Initial prompt sent as the first turn. Optional — callers can also
           create an empty agent and use /send for the first interaction.
+        example: You are an on-call assistant.
         type: string
       workdir:
         description: Working directory inside the container.
+        example: /workspace
         type: string
     type: object
   stromboli_internal_agent.Snapshot:
@@ -1544,8 +1558,7 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/internal_api.JobCancelResponse'
         "404":
           description: Job not found
           schema:

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -12,6 +12,8 @@ package agent
 import (
 	"sync"
 	"time"
+
+	"stromboli/internal/types"
 )
 
 // Status captures the current lifecycle state of an Agent.
@@ -31,19 +33,21 @@ const (
 )
 
 // CreateRequest is the operator-supplied configuration for a new Agent.
+//
+// @Description Configuration for spawning a long-lived Claude agent
 type CreateRequest struct {
 	// Initial prompt sent as the first turn. Optional — callers can also
 	// create an empty agent and use /send for the first interaction.
-	Prompt string `json:"prompt,omitempty"`
+	Prompt string `json:"prompt,omitempty" example:"You are an on-call assistant."`
 	// Working directory inside the container.
-	Workdir string `json:"workdir,omitempty"`
+	Workdir string `json:"workdir,omitempty" example:"/workspace"`
 	// Idle-timeout override in seconds. Zero means "use the manager default
 	// (DefaultIdleTimeout)". Negative values are rejected at parse time.
-	IdleTimeoutSeconds int `json:"idle_timeout_seconds,omitempty"`
-	// Free-form Claude CLI options forwarded to the command builder.
-	// Kept as map[string]any so we can evolve the surface without bumping the
-	// CreateRequest schema every time Claude adds a flag.
-	Claude map[string]any `json:"claude,omitempty"`
+	IdleTimeoutSeconds int `json:"idle_timeout_seconds,omitempty" example:"1800"`
+	// Claude CLI options forwarded to the command builder. Same shape as
+	// RunRequest.claude so callers don't have to learn two schemas — the
+	// field is fully typed in OpenAPI rather than a freeform object.
+	Claude *types.ClaudeOptions `json:"claude,omitempty"`
 }
 
 // Event is one entry in the SSE stream the runtime pushes to subscribers.

--- a/internal/api/async.go
+++ b/internal/api/async.go
@@ -42,6 +42,13 @@ type JobListResponse struct {
 	Jobs []*JobResponse `json:"jobs"`
 }
 
+// JobCancelResponse is returned by DELETE /jobs/{id} on a successful cancel.
+// @Description Result of a job cancel request
+type JobCancelResponse struct {
+	Cancelled bool   `json:"cancelled" example:"true"`
+	JobID     string `json:"job_id" example:"job-abc123def456"`
+}
+
 // runAsync starts Claude execution asynchronously
 // @Summary Run Claude async
 // @Description Starts Claude Code execution asynchronously and returns a job ID
@@ -222,7 +229,7 @@ func (s *Server) listJobs(c *gin.Context) {
 // @Tags jobs
 // @Produce json
 // @Param id path string true "Job ID"
-// @Success 200 {object} map[string]interface{}
+// @Success 200 {object} JobCancelResponse
 // @Failure 404 {object} RunResponse "Job not found"
 // @Failure 409 {object} RunResponse "Job cannot be cancelled"
 // @Router /jobs/{id} [delete]
@@ -249,9 +256,9 @@ func (s *Server) cancelJob(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
-		"cancelled": true,
-		"job_id":    jobID,
+	c.JSON(http.StatusOK, JobCancelResponse{
+		Cancelled: true,
+		JobID:     jobID,
 	})
 }
 


### PR DESCRIPTION
## Summary

You spotted that the persistent-agent spawn endpoint took an opaque \`any\` in the OpenAPI spec. That was the visible symptom of a wider issue — two endpoints had weakly-typed bodies. Fixed both.

### \`POST /agents\` — \`claude\` field rendered as opaque object

\`agent.CreateRequest.Claude\` was \`map[string]any\`. The generated spec rendered it as:

\`\`\`yaml
claude:
  additionalProperties: {}
  type: object
\`\`\`

— losing the entire Claude CLI option schema. Client codegens couldn't help users discover \`model\`, \`effort\`, \`allowed_tools\`, etc. for the persistent-agents path even though they could for \`/run\`.

Changed to \`*types.ClaudeOptions\`, the **same** struct \`RunRequest.claude\` uses. Now the spec \`$ref\`s a single \`ClaudeOptions\` definition across both endpoints — callers learn one schema.

The field was inert (never threaded through to the argv builder yet — separate scope), so this is a pure schema win with no runtime change.

### \`DELETE /jobs/{id}\` — response was \`gin.H\`

The handler returned \`gin.H{\"cancelled\": true, \"job_id\": jobID}\`, swaggered as \`map[string]interface{}\`. Added a typed \`JobCancelResponse {cancelled, job_id}\` and switched the handler to return it directly.

### Bonus polish

Added \`@Description\` annotations and \`example:\` tags to \`CreateRequest\` fields so the rendered schema is more useful for codegen tools.

### Regenerated specs

Ran \`make docs-swagger\` to regenerate \`docs/swagger/{docs.go,swagger.json,swagger.yaml}\`. Verified the new \`claude\` field is now:

\`\`\`yaml
claude:
  allOf:
  - \$ref: '#/definitions/stromboli_internal_types.ClaudeOptions'
\`\`\`

## Test plan

- [x] \`go build ./...\` passes (golang:1.26 in podman)
- [x] \`go test ./...\` passes — no regressions in any package (one pre-existing flake in agent/process_test.go observed across runs but not introduced here)
- [ ] CI green
- [ ] Smoke: hit \`/swagger/index.html\` after merge and verify the \`POST /agents\` body editor offers Claude option fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)