### PR TITLE
docs: add guides for persistent agents, performance tuning, webhook security

### DIFF
--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -59,15 +59,16 @@ This split means you can use any language runtime without rebuilding Claude into
 
 ## Execution modes
 
-Stromboli supports three ways to run agents:
+Stromboli supports four ways to run agents:
 
 | Mode | Endpoint | Use case |
 |------|----------|----------|
 | **Sync** | `POST /run` | Short tasks — get the result in the response |
 | **Async** | `POST /run/async` | Long tasks — get a `job_id`, poll for results |
 | **Streaming** | `GET /run/stream` | Real-time output via Server-Sent Events |
+| **Persistent** | `POST /agents` then `/agents/:id/send` | Many short turns against a warm process — sub-second latency |
 
-All three modes create the same container behind the scenes. The difference is how you receive the output.
+The first three create a container per request and tear it down when the run ends. The persistent mode keeps a single container alive across many turns; you pay the 2–3 s spawn cost once instead of every call. See the [persistent agents guide](../guides/persistent-agents.md).
 
 ## Sessions
 

--- a/docs/guides/performance-tuning.md
+++ b/docs/guides/performance-tuning.md
@@ -1,0 +1,125 @@
+# Performance & Cost Tuning
+
+Stromboli passes through a handful of Claude CLI levers that change how requests are billed and how fast they return. They live under `claude.*` on `RunRequest` and `agent.CreateRequest` and most map to environment variables the Claude CLI reads internally. This guide groups them by intent.
+
+## Track what you're spending
+
+Every `/run` response carries a `usage` block:
+
+```json
+{
+  "id": "run-abc",
+  "status": "completed",
+  "output": "...",
+  "session_id": "550e...",
+  "usage": {
+    "model": "claude-sonnet-4-6",
+    "input_tokens": 1234,
+    "output_tokens": 567,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 8901,
+    "total_tokens": 10702,
+    "estimated_cost_usd": 0.0142
+  }
+}
+```
+
+`estimated_cost_usd` is computed best-effort from the per-model price table. `cache_read_input_tokens` is what you saved by hitting Claude's prompt cache (priced at ~10% of fresh input).
+
+Async jobs surface the same field on `GET /jobs/{id}.usage`, populated when the job completes. Persistent agents don't return per-turn usage on `/send` — read the session JSONL instead via `GET /sessions/{session_id}/messages`.
+
+!!! tip "Hard budget caps"
+    Set `claude.max_budget_usd` to short-circuit a run when projected cost exceeds the cap. Useful when you don't trust a recursive agent loop to terminate.
+
+## Effort levels
+
+`claude.effort` sets how aggressively the model thinks before responding. Valid values per the upstream CLI: `low`, `medium`, `high`, `xhigh`, `max`. The accepted subset depends on the model — Stromboli passes through; Claude rejects unsupported levels at runtime.
+
+```json
+{
+  "prompt": "Refactor this distributed lock for correctness under network partitions",
+  "claude": {"model": "sonnet", "effort": "high"}
+}
+```
+
+Higher effort ⇒ more thinking tokens ⇒ slower + more expensive. For routine code edits, `medium` is plenty. Reserve `high`/`xhigh` for design-level reasoning, multi-step refactors, or correctness-critical work where you'd rather the model think twice.
+
+## Prompt caching TTL
+
+When the same context (system prompt, repo state, long instructions) gets re-used across many turns, Claude's prompt cache reads at ~10% the price of fresh input. The default cache TTL is short; for long-lived agents that re-use the same context for hours, extend it:
+
+```json
+{"claude": {"prompt_caching_ttl": "1h"}}
+```
+
+Mapping:
+
+| Value | Effect | Env var set |
+|---|---|---|
+| `""` | Use Claude's default | _none_ |
+| `"5m"` | Force the 5-minute cache | `FORCE_PROMPT_CACHING_5M=1` |
+| `"1h"` | Enable the 1-hour cache | `ENABLE_PROMPT_CACHING_1H=1` |
+
+Best fit:
+
+- **Persistent agents** with a long system prompt that stays constant → `1h` is a no-brainer.
+- **Synchronous `/run`** calls that share a system prompt across many requests in the same hour → `1h` and the second-onward call hits cache.
+- **Single one-shot runs** → leave default; the cache won't pay off in a single turn.
+
+## Bedrock service tier
+
+When running against AWS Bedrock as the model backend, `claude.bedrock_service_tier` chooses the throughput tier:
+
+| Value | Use case |
+|---|---|
+| `default` | Standard rate limits |
+| `flex` | Lower priority, lower per-token rate |
+| `priority` | Higher priority, premium rate |
+
+```json
+{"claude": {"bedrock_service_tier": "flex"}}
+```
+
+Maps to `ANTHROPIC_BEDROCK_SERVICE_TIER`. Ignored when not on Bedrock — safe to set unconditionally if your fleet is mixed.
+
+## Native PowerShell on Windows agent hosts
+
+If the agent container's host OS is Windows and you want Claude to use the native PowerShell tool instead of a POSIX shell:
+
+```json
+{"claude": {"enable_powershell_tool": true}}
+```
+
+Sets `CLAUDE_CODE_USE_POWERSHELL_TOOL=1`. No-op on Linux/macOS containers. Most Stromboli operators run Linux agent images; this matters mainly for Windows-targeted automation work.
+
+## Combining for lowest cost
+
+A "cheap-but-good-enough" persistent agent template:
+
+```json
+{
+  "prompt": "...long stable system prompt...",
+  "idle_timeout_seconds": 3600,
+  "claude": {
+    "model": "sonnet",
+    "effort": "medium",
+    "prompt_caching_ttl": "1h",
+    "max_budget_usd": 5.00
+  }
+}
+```
+
+What this buys you:
+
+- One spawn cost amortized over hours of activity (persistent agent)
+- 1-hour prompt cache means the long system prompt costs full price once, then ~10% per turn
+- `medium` effort keeps thinking tokens bounded
+- `max_budget_usd: 5` is the safety net if a turn loops
+
+For one-shot review jobs, keep it simple — just `model` + `effort: medium` and let the rest default.
+
+## What to read next
+
+- [API endpoints reference](../api/endpoints.md) — every `claude.*` field, all in one place
+- [Persistent agents](persistent-agents.md) — when to keep an agent warm vs. one-shot
+- [Configuration](../getting-started/configuration.md) — env vars that override per-request defaults at the deployment level

--- a/docs/guides/persistent-agents.md
+++ b/docs/guides/persistent-agents.md
@@ -1,0 +1,200 @@
+# Persistent Agents
+
+A persistent agent is a long-lived Claude process kept alive across many turns. Once spawned, it accepts prompts via `POST /agents/{id}/send`, streams output via Server-Sent Events on `GET /agents/{id}/stream`, and stays warm until you delete it or its idle timeout fires.
+
+## When to use one
+
+Use a persistent agent when:
+
+- **Latency matters per-turn.** `/run` cold-starts a container on every call (2–3 s). A warm agent answers in sub-second.
+- **The conversation has many short turns.** On-call bots, Slack assistants, sensor-bus reactors — anything event-driven where the next turn arrives in seconds.
+- **You want streaming output by default.** SSE is built in; clients consume `output` / `turn_start` / `turn_end` events as they happen.
+
+Use plain `/run` (or `/run/async`) instead when:
+
+- The work is one-shot ("review this PR"). Spawning + tearing down per request is fine.
+- You don't have a place to keep an agent ID alive between requests.
+- You need to lock down resource usage to a single bounded execution.
+
+## Lifecycle
+
+A persistent agent moves through four states:
+
+```mermaid
+stateDiagram-v2
+    [*] --> starting: POST /agents
+    starting --> idle: first stdout line
+    idle --> generating: POST /agents/:id/send
+    generating --> idle: turn_end event
+    idle --> exited: DELETE /agents/:id<br/>or idle timeout
+    generating --> exited: process exit / error
+    exited --> [*]: record removed
+```
+
+| Status | What it means |
+|---|---|
+| `starting` | Container booting; Claude hasn't reported readiness yet. `/send` returns `503`. |
+| `idle` | Alive and ready for the next turn. |
+| `generating` | A turn is in flight. Concurrent `/send` returns `409`. |
+| `exited` | Process or container has stopped. Record persists briefly so you can read `exit_error`. |
+
+## Spawning
+
+```bash
+curl -X POST localhost:8080/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "You are an on-call assistant. Wait for incident reports.",
+    "workdir": "/workspace",
+    "idle_timeout_seconds": 1800,
+    "claude": {
+      "model": "sonnet",
+      "allowed_tools": ["Read", "Bash", "Grep"]
+    }
+  }'
+```
+
+```json
+{
+  "id": "agent-abc123",
+  "session_id": "550e8400-...",
+  "status": "starting",
+  "idle_timeout_seconds": 1800,
+  "turns_completed": 0,
+  "created_at": "2026-05-01T08:00:00Z"
+}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `prompt` | no | Sent as the first turn. Omit for an "empty" agent that waits for `/send`. |
+| `workdir` | no | Working directory inside the container, same semantics as `/run`. |
+| `idle_timeout_seconds` | no | Override the manager-wide default. `0` keeps the default (30 min). Negative values are rejected. |
+| `claude` | no | Same `ClaudeOptions` shape as `/run`. Pick model, tools, system prompt, etc. |
+
+The same `claude` schema means a working `/run` request body almost copy-pastes into `/agents` — there's no second schema to learn.
+
+## Sending turns
+
+```bash
+curl -X POST localhost:8080/agents/agent-abc123/send \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "What is the status of incident INC-417?"}'
+```
+
+```json
+{"turn_id": "turn-def456"}
+```
+
+`/send` returns immediately with the new turn's ID. Output streams via `/stream` (next section). The agent stays in `generating` until the turn completes.
+
+If you send while a turn is already running you get `409 Conflict (ErrAgentBusy)`. If the agent has exited you get `410 Gone (ErrAgentExited)`. If it hasn't booted yet you get `503 (ErrAgentNotReady)`.
+
+## Streaming output
+
+Open one SSE connection per agent (or per UI tab) and read events as they arrive:
+
+```bash
+curl -N localhost:8080/agents/agent-abc123/stream
+```
+
+```
+event: turn_start
+data: {"type":"turn_start","turn_id":"turn-def456","at":"2026-05-01T08:00:01Z"}
+
+event: output
+data: {"type":"output","turn_id":"turn-def456","content":"Looking at INC-417...","at":"..."}
+
+event: output
+data: {"type":"output","turn_id":"turn-def456","content":"...","at":"..."}
+
+event: turn_end
+data: {"type":"turn_end","turn_id":"turn-def456","at":"..."}
+```
+
+Event types:
+
+- `turn_start` — fires when `/send` accepts a new turn
+- `output` — one event per Claude stdout line (verbatim, you decide whether it's stream-json that needs parsing)
+- `turn_end` — turn completed cleanly
+- `error` — Claude wrote to stderr or a turn errored
+- `exited` — agent's process has stopped; the channel will close after this
+- `closed` — fired when your subscription ends because the agent was deleted
+
+Multiple subscribers per agent are fine — each gets its own buffered channel. Slow subscribers may drop events (capacity 32 per subscriber); a dropped event is the contract trade-off for not letting one stuck client stall the whole agent.
+
+!!! tip "Reconnects"
+    SSE clients should reconnect on transient drops. Stromboli does not replay missed events — when you reconnect, you start at the next event. If you need full transcript replay, fetch `GET /sessions/{session_id}/messages` separately.
+
+## Idle timeout
+
+Each agent tracks `last_activity_at` (updated on every `/send`). A background watchdog wakes every 30 s; if `last_activity_at` is older than `idle_timeout_seconds`, the agent is stopped automatically and an `exited` event is fanned out with the error `agent: idle timeout reached`.
+
+This is the cost-control gate. A forgotten agent eats container memory and the Claude budget; the timeout makes "leak by leaving" hard.
+
+Pick the timeout to match your workload:
+
+- Chat-style assistant where prompts arrive every few minutes → 30 min (default) is fine
+- On-call agent that may sit silent for an hour between alerts → 2–4 hours
+- High-frequency sensor reactor where prompts are seconds apart → 5–15 min is tighter and cheaper
+
+The watchdog ticks every 30 s, so the actual stop time is `idle_timeout_seconds + (0..30s)`.
+
+## Deleting
+
+```bash
+curl -X DELETE localhost:8080/agents/agent-abc123
+```
+
+`204 No Content` on success, `404` if the agent doesn't exist (already deleted or never spawned).
+
+`DELETE` sends `SIGTERM` to the process group, waits 5 s for graceful exit, then `SIGKILL`. Subscribers get a final `exited` event, their SSE channels close, and the registry forgets the agent.
+
+## Worked example: an on-call bot
+
+```python
+import requests, sseclient
+
+# 1. Spawn once, at service start
+r = requests.post("http://localhost:8080/agents", json={
+    "prompt": "You triage incidents. Reply with severity (P0..P3) and one-line diagnosis.",
+    "idle_timeout_seconds": 14400,  # 4h
+    "claude": {"model": "sonnet"},
+}).json()
+agent_id = r["id"]
+
+# 2. One streaming consumer for the whole service lifetime
+def consume():
+    with requests.get(f"http://localhost:8080/agents/{agent_id}/stream", stream=True) as resp:
+        for ev in sseclient.SSEClient(resp).events():
+            if ev.event == "output":
+                print(ev.data)
+            elif ev.event == "exited":
+                break
+
+# 3. Per-incident: just /send, no spawn cost
+def triage(report: str) -> str:
+    return requests.post(
+        f"http://localhost:8080/agents/{agent_id}/send",
+        json={"prompt": report},
+    ).json()["turn_id"]
+
+# 4. Tear down at SIGTERM
+def shutdown():
+    requests.delete(f"http://localhost:8080/agents/{agent_id}")
+```
+
+A single agent handles every incident the service receives. Cold start happens once at boot, then triages run in milliseconds.
+
+## Operational notes
+
+- **One container per agent.** Each agent holds a podman container open for its full lifetime. Capacity-plan accordingly: 100 simultaneous agents = 100 containers.
+- **No multi-process safety.** The `Manager` is process-local. If you horizontally scale Stromboli, each replica has its own agent registry — operators should pin a given agent's traffic to the replica that spawned it (e.g. via session affinity), or use a single replica for the agent fleet.
+- **Graceful shutdown.** On `SIGTERM`, Stromboli calls `StopAll()` and waits for every agent's process group to exit before the API server closes — you won't leak orphan podman containers.
+- **Inspecting state.** `GET /agents` lists every agent and its snapshot; `GET /agents/{id}` returns one. Both are read-only and cheap.
+
+## See also
+
+- [API endpoints reference](../api/endpoints.md#persistent-agents) — full request/response shapes
+- [Sessions](sessions.md) — every agent has a session under the hood; transcript retrieval works the same way
+- [Lifecycle hooks](lifecycle-hooks.md) — agents honour the same `OnCreateCommand` / `PostCreate` / `PostStart` hooks that `/run` does

--- a/docs/guides/running-agents.md
+++ b/docs/guides/running-agents.md
@@ -152,10 +152,17 @@ Tips:
 - Make sure `workdir` matches where your volume is mounted
 - Mount specific project directories, not entire home folders
 
+## When to keep an agent warm
+
+If you're calling `/run` repeatedly with similar context (same system prompt, same workspace, prompts arriving every few seconds), the 2–3 s spawn cost dominates. [Persistent agents](persistent-agents.md) keep the container open across many turns — sub-second turn latency, same `claude` schema, with an idle timeout to keep cost bounded.
+
 ## What's next
 
+- [Persistent agents](persistent-agents.md) — Long-lived Claude processes for event-driven workloads
 - [Sessions](sessions.md) — Resume conversations across requests
 - [Secrets](secrets.md) — Inject tokens for GitHub, GitLab, etc.
 - [Custom images](custom-images.md) — Use Python, Node, Go, or any glibc image
 - [Lifecycle hooks](lifecycle-hooks.md) — Install deps, start services before Claude runs
 - [Compose environments](compose-environments.md) — Multi-service stacks with databases
+- [Performance & cost tuning](performance-tuning.md) — Caching, effort levels, budget caps
+- [Webhook security](webhook-security.md) — Verify async callbacks with HMAC-SHA256

--- a/docs/guides/sessions.md
+++ b/docs/guides/sessions.md
@@ -140,3 +140,20 @@ graph TB
 ```
 
 If `SESSIONS_HOST_DIR` is not set, it defaults to `SESSIONS_DIR`. This only works when running Stromboli directly on the host.
+
+## Session titles
+
+`GET /sessions` returns each session's ID **and** an optional human title:
+
+```json
+{
+  "sessions": [
+    {"id": "550e8400-...", "title": "Refactor billing service"},
+    {"id": "6ba7b810-...", "title": ""}
+  ]
+}
+```
+
+Titles are populated when an agent's `UserPromptSubmit` hook returns `hookSpecificOutput.sessionTitle`. Claude Code's interactive `/rename` command does this automatically; headless callers can replicate the behaviour by configuring a hook in the agent's settings file.
+
+Title lookup is best-effort — a missing or unreadable session JSONL surfaces an empty title rather than failing the whole list response.

--- a/docs/guides/webhook-security.md
+++ b/docs/guides/webhook-security.md
@@ -1,0 +1,170 @@
+# Webhook Security
+
+Stromboli can POST to a callback URL when an async job completes (the `webhook_url` field on `/run/async`). By default those callbacks are unsigned — your receiver has no way to distinguish a genuine Stromboli notification from a forged one. This guide covers the signing flow and the related trusted-proxy setting that locks down rate-limit identity.
+
+## Why sign
+
+If your receiver acts on the callback (closes a ticket, deploys code, posts to Slack), an unsigned callback is a side-channel for anyone who can guess the URL. They send a forged "completed" event, you trigger a real action.
+
+Signing turns the callback into something only a holder of the shared secret could produce. The receiver verifies before acting; forged calls get rejected.
+
+## Server-side setup
+
+Set a secret on the Stromboli process (32+ random bytes is fine):
+
+```bash
+export STROMBOLI_WEBHOOK_SIGNING_SECRET="$(openssl rand -base64 32)"
+./bin/stromboli
+```
+
+On startup the server logs:
+
+```
+INFO Webhook signing enabled (HMAC-SHA256)
+```
+
+If you forget, you instead get a loud `WARN` that callbacks will ship unsigned. That's deliberate — silent unsigned sends are how production deployments end up with a forgery vulnerability nobody noticed.
+
+Once enabled, every async job webhook carries two extra headers:
+
+```
+X-Stromboli-Timestamp: 1735726800
+X-Stromboli-Signature: sha256=4f8c2a7b...
+```
+
+The signature is HMAC-SHA256 over `timestamp + "." + body`, hex-encoded.
+
+## Receiver-side verification
+
+### Go (using the helper Stromboli ships)
+
+Stromboli's `webhook` package exports a `Verify` helper so receivers don't have to roll their own HMAC code:
+
+```go
+import "stromboli/internal/webhook"
+
+func handle(w http.ResponseWriter, r *http.Request) {
+    body, _ := io.ReadAll(r.Body)
+    err := webhook.Verify(
+        []byte(os.Getenv("STROMBOLI_WEBHOOK_SIGNING_SECRET")),
+        r.Header.Get(webhook.HeaderTimestamp),
+        r.Header.Get(webhook.HeaderSignature),
+        body,
+        5*time.Minute, // freshness window
+    )
+    if err != nil {
+        http.Error(w, "invalid signature", http.StatusUnauthorized)
+        return
+    }
+    // ...act on the verified body...
+}
+```
+
+The freshness window rejects timestamps older than the bound — a leaked signature can't be replayed indefinitely. 5 minutes is a reasonable starting point; tighten if your receiver is on a tightly-clocked network.
+
+### Python
+
+```python
+import hmac, hashlib, time
+from flask import Flask, request, abort
+
+SECRET = os.environ["STROMBOLI_WEBHOOK_SIGNING_SECRET"].encode()
+MAX_AGE = 300  # 5 min
+
+@app.post("/hook")
+def hook():
+    ts = request.headers.get("X-Stromboli-Timestamp", "")
+    sig = request.headers.get("X-Stromboli-Signature", "")
+    body = request.get_data()
+
+    if not ts or not sig:
+        abort(401, "missing signature headers")
+
+    try:
+        ts_int = int(ts)
+    except ValueError:
+        abort(401, "invalid timestamp")
+    if abs(time.time() - ts_int) > MAX_AGE:
+        abort(401, "timestamp outside freshness window")
+
+    expected = hmac.new(SECRET, f"{ts}.".encode() + body, hashlib.sha256).hexdigest()
+    provided = sig.removeprefix("sha256=")
+    if not hmac.compare_digest(expected, provided):
+        abort(401, "signature mismatch")
+
+    # ...act on the verified body...
+    return "", 204
+```
+
+`hmac.compare_digest` is critical — a normal `==` leaks timing info that lets attackers recover the signature byte-by-byte.
+
+### Node
+
+```js
+import crypto from "node:crypto";
+
+function verify(req, secret, maxAgeSec = 300) {
+  const ts = req.headers["x-stromboli-timestamp"];
+  const sig = req.headers["x-stromboli-signature"];
+  if (!ts || !sig) throw new Error("missing signature headers");
+
+  const tsInt = parseInt(ts, 10);
+  if (Math.abs(Date.now() / 1000 - tsInt) > maxAgeSec) {
+    throw new Error("timestamp outside freshness window");
+  }
+
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(`${ts}.`)
+    .update(req.rawBody) // requires raw body — see your framework's docs
+    .digest("hex");
+
+  const provided = sig.replace(/^sha256=/, "");
+  const a = Buffer.from(expected, "hex");
+  const b = Buffer.from(provided, "hex");
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+    throw new Error("signature mismatch");
+  }
+}
+```
+
+The receiver MUST hash the **raw bytes** of the request body, not a JSON-reparse. If your framework auto-parses JSON, configure it to keep the raw payload around (express: `express.raw({type: 'application/json'})` then re-parse later, fastify: `rawBody: true`, etc.).
+
+## Retry semantics
+
+Stromboli retries each webhook once after 100 ms. The retry **reuses the same timestamp and signature** as the original send. Your receiver's freshness check should evaluate the original send time, not the retry time — clients that recompute timestamps per retry will fail when the original had a few seconds of clock skew.
+
+If your receiver returns a 2xx response, the webhook is considered delivered. Anything else triggers the one retry, then Stromboli logs and gives up. There is no exponential backoff or DLQ; if reliable delivery matters, hold the receiver behind a queue you control.
+
+## Rotating the secret
+
+There is no built-in rotation flow yet. To rotate without dropping in-flight callbacks:
+
+1. Configure your receiver to accept signatures from **either** the old or new secret for an overlap window
+2. Update `STROMBOLI_WEBHOOK_SIGNING_SECRET` and restart Stromboli
+3. After the freshness window has passed (5 min is enough), drop the old secret on the receiver
+
+## Trusted proxies for rate limiting
+
+Related but distinct: rate limiting decides who's making a request, which can be spoofed via `X-Forwarded-For` if the server trusts that header blindly. Stromboli ignores forwarding headers by default and only honours them when the immediate peer is in a configured allowlist:
+
+```bash
+# Comma-separated CIDRs (or bare IPs) of proxies you trust.
+export STROMBOLI_RATE_LIMIT_TRUSTED_PROXIES="10.0.0.0/8,172.16.0.0/12"
+```
+
+When set, requests arriving from those CIDRs may include `X-Forwarded-For`; the leftmost (original-client) entry becomes the rate-limit bucket key. From any other source, forwarding headers are ignored and the immediate peer is used.
+
+Rule of thumb:
+
+- **Direct exposure** (no proxy) → leave empty. Don't honor headers nobody is supposed to send.
+- **Behind a single trusted reverse proxy** → set its private CIDR.
+- **Behind a CDN with rotating egress IPs** → set the CDN's documented egress range. Don't list `0.0.0.0/0` — that defeats the purpose.
+
+If you skip this and run behind a proxy, every authenticated client appears as the same IP (the proxy's), and your per-IP rate limits become per-cluster rate limits. If you skip it and run with direct exposure, anyone can spoof their bucket. Either way: configure the allowlist that matches your topology.
+
+## See also
+
+- [API endpoints reference](../api/endpoints.md) — `webhook_url` on `/run/async`
+- [Configuration](../getting-started/configuration.md) — both env vars in the table
+- [Production hardening](../security/production.md) — checklist that includes signing

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,14 @@ curl -X POST http://localhost:8080/run \
 
     Multi-service stacks with databases, caches, and more.
 
+- :material-clock-fast: **Persistent Agents**
+
+    Long-lived Claude processes for [event-driven workloads](guides/persistent-agents.md) — sub-second turn latency.
+
+- :material-shield-check: **Signed Webhooks**
+
+    HMAC-SHA256 callbacks so receivers can [verify authenticity](guides/webhook-security.md).
+
 </div>
 
 ## Get started

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,11 +108,14 @@ nav:
     - Configuration: getting-started/configuration.md
   - Guides:
     - Running Agents: guides/running-agents.md
+    - Persistent Agents: guides/persistent-agents.md
     - Sessions: guides/sessions.md
     - Secrets: guides/secrets.md
     - Custom Images: guides/custom-images.md
     - Lifecycle Hooks: guides/lifecycle-hooks.md
     - Compose Environments: guides/compose-environments.md
+    - Performance & Cost Tuning: guides/performance-tuning.md
+    - Webhook Security: guides/webhook-security.md
     - Client Examples: guides/client-examples.md
   - Security:
     - Overview: security/overview.md


### PR DESCRIPTION
## Summary

You spotted that the v0.5.0-alpha release shipped substantial new functionality with the API endpoints reference covered but the conceptual / how-to surface still describing the smaller v0.3.0 product. Operators landing on the guides section had no path to discover **persistent agents**, **prompt caching TTL**, **effort levels**, **Bedrock tier**, **token cost tracking**, or **webhook signature verification** — every one of these features lived only in the endpoints reference or the configuration table.

## Three new guides

### \`guides/persistent-agents.md\` (the priority gap you called out)

- When to use a persistent agent vs. \`/run\` (latency, statefulness, event-driven)
- Lifecycle state machine (\`starting\` → \`idle\` → \`generating\` → \`exited\`) with a Mermaid diagram
- \`POST /agents\`, \`POST /agents/:id/send\`, \`GET /agents/:id/stream\`, \`DELETE /agents/:id\` with full request/response shapes
- SSE event types and reconnect semantics
- Idle-timeout behaviour as the cost-control gate, with sizing guidance per workload type
- Worked example: on-call triage bot in Python (spawn once, stream forever, send per incident, delete on shutdown)
- Operational notes: container-per-agent capacity planning, no multi-process safety, graceful shutdown semantics

### \`guides/performance-tuning.md\`

Bundles all the per-request \"cost knobs\" that were scattered across the endpoints reference:

- \`RunResponse.usage\` — what each field means, where async jobs surface it, where persistent agents don't
- \`claude.effort\` — when each level is worth the tokens
- \`claude.prompt_caching_ttl\` (\`5m\` / \`1h\`) — workload patterns where each pays off
- \`claude.bedrock_service_tier\` — flex/default/priority on Bedrock
- \`claude.enable_powershell_tool\` — Windows-host edge case
- Combination template for a low-cost persistent agent

### \`guides/webhook-security.md\`

- Why sign at all (forge protection, replay protection)
- Server-side setup with the loud-WARN-on-missing semantic
- Go / Python / Node verification snippets, with the constant-time-compare gotcha called out
- Retry semantics (same timestamp + signature reused — receivers must check the original send time)
- Secret-rotation playbook
- Trusted-proxy allowlist (\`STROMBOLI_RATE_LIMIT_TRUSTED_PROXIES\`) — related rate-limit-identity setting included so operators don't miss it

## Cross-link updates

- \`index.md\` feature grid mentions persistent agents and signed webhooks
- \`concepts/how-it-works.md\` execution-modes table grew from 3 to 4 modes; persistent agents linked
- \`guides/running-agents.md\` gets a \"when to keep an agent warm\" subsection plus the new guides in \"What's next\"
- \`guides/sessions.md\` gets a \"Session titles\" section explaining the \`UserPromptSubmit\` hook behaviour from #83/#86
- \`mkdocs.yml\` nav adds the three new guides under Guides

## Test plan

- [ ] \`mkdocs serve\` locally and verify all three guides render with their Mermaid diagrams + admonitions
- [ ] Confirm the nav reflects the new structure and there are no broken intra-doc links
- [ ] CI green
- [ ] Skim the live docs site once the deploy job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)