### PR TITLE
docs: add v0.5.0 upgrade guide and refresh production hardening

### DIFF
--- a/docs/getting-started/upgrade-to-0.5.0.md
+++ b/docs/getting-started/upgrade-to-0.5.0.md
@@ -1,0 +1,205 @@
+# Upgrading to v0.5.0-alpha
+
+v0.5.0-alpha is the largest release since v0.3.0-alpha. It ships substantial new functionality (persistent agents, webhook signing, pluggable token blacklist) plus four operationally-breaking default changes that existing deployments must address before restarting.
+
+This page is the migration playbook. Read the [changelog](../changelog.md) for the full feature list.
+
+## TL;DR checklist
+
+If you're upgrading an existing deployment, work through this list in order:
+
+- [ ] **Set a real JWT secret** — auth is now on by default, server fails fast without one
+- [ ] **Update Prometheus scrape config** — `/metrics` moved to `127.0.0.1:9090` on a separate listener
+- [ ] **Configure tracing TLS** — `insecure: false` is now the default; either provide TLS to your collector or set `STROMBOLI_TRACING_INSECURE=true` for localhost
+- [ ] **Verify log parsing** — JSON is now the default log format; `STROMBOLI_LOG_FORMAT=text` if your aggregator expects plain text
+- [ ] **Drop Windows binaries from your fleet** — they're no longer published; run via WSL2 or a Linux container
+- [ ] **(Recommended) Sign outgoing webhooks** — set `STROMBOLI_WEBHOOK_SIGNING_SECRET` and verify on receivers
+- [ ] **(Recommended) Pick a blacklist backend** — `memory` is fine for single-instance; `bolt` for durability across restart
+
+Each item below explains what changed, why, how to verify, and how to opt out if you have to.
+
+---
+
+## Auth on by default
+
+**What changed.** `STROMBOLI_AUTH_ENABLED` defaults to `true`. The server refuses to start if `STROMBOLI_JWT_SECRET` is empty, shorter than 32 characters, or matches a known placeholder string (`change-me`, `your-jwt-secret`, etc.).
+
+**Why.** Defaults that ship insecure get pushed to production. The old `false` default meant operators had to remember to flip the switch — now production fails loud at boot rather than silently exposing an unauthenticated API.
+
+**Migration.**
+
+```bash
+export STROMBOLI_JWT_SECRET="$(openssl rand -base64 32)"
+./bin/stromboli
+```
+
+You should see in the startup logs:
+
+```
+INFO Authentication enabled tokens=0
+INFO JWT authentication enabled access_expiry=24h refresh_expiry=168h
+```
+
+**Opt-out (dev only).** If you genuinely need an unauthenticated server (local dev, ephemeral CI runner, etc.):
+
+```bash
+export STROMBOLI_AUTH_ENABLED=false
+```
+
+The startup log will say `INFO Authentication disabled`. **Do not deploy this way.**
+
+**Failure mode.** If you upgrade without setting a secret, you'll see:
+
+```
+ERROR Failed to load configuration error="invalid configuration: auth is enabled but STROMBOLI_JWT_SECRET is empty — generate one with: openssl rand -base64 32"
+```
+
+The process exits with code 1.
+
+---
+
+## Metrics on a separate localhost listener
+
+**What changed.** `/metrics` is no longer mounted on the main API router. It's served from its own `http.Server` bound to `127.0.0.1:9090` by default. The main API port (`:8080` by default) no longer exposes Prometheus metrics at all.
+
+**Why.** Co-locating `/metrics` on the public port meant a forgotten ingress rule could leak operational data (job counts, cardinality of session IDs, error rate signals) to the internet. A separate listener forces a deliberate decision to expose it.
+
+**Migration.**
+
+If your Prometheus runs on the same host:
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: 'stromboli'
+    static_configs:
+      - targets: ['127.0.0.1:9090']  # was 'stromboli:8080'
+```
+
+If your Prometheus is in another pod / namespace, you have two options:
+
+1. **Sidecar pattern (recommended).** Run a Prometheus scrape agent in the same pod; it talks to `localhost:9090` and forwards. The cluster-internal traffic crosses no untrusted boundaries.
+2. **Bind on a private interface.** Override the address:
+   ```bash
+   export STROMBOLI_METRICS_ADDRESS="10.0.5.7:9090"  # the pod's private interface
+   ```
+   And add a NetworkPolicy that restricts ingress on `9090` to the Prometheus pod only.
+
+!!! danger "Don't bind metrics to 0.0.0.0"
+    The Kubernetes manifests we ship default to `127.0.0.1:9090` for a reason. If you override to `0.0.0.0:9090` to satisfy a Prometheus that doesn't support sidecars, pair it with a NetworkPolicy. An exposed metrics endpoint leaks more than people expect — request rates, session enumeration, error spikes correlating with deploy times.
+
+**Verify.**
+
+```bash
+curl http://127.0.0.1:9090/metrics | head -3       # should return Prometheus text
+curl http://localhost:8080/metrics                 # should 404
+```
+
+---
+
+## Tracing TLS by default
+
+**What changed.** `STROMBOLI_TRACING_INSECURE` flipped from `true` to `false`. The OpenTelemetry exporter now uses TLS by default and expects the OTLP collector to present a valid certificate.
+
+**Why.** Plaintext OTLP leaks request URLs, session IDs, and internal routing details to anyone on the network path. The default belongs on the secure side.
+
+**Migration.**
+
+If your collector is on `localhost` or a trusted private network:
+
+```bash
+export STROMBOLI_TRACING_INSECURE=true
+```
+
+If your collector is reachable over the public network:
+
+- Make sure it presents a TLS certificate (most managed collectors do)
+- Make sure the certificate's subject matches the hostname in `STROMBOLI_TRACING_ENDPOINT`
+- Use the system root CA store (Stromboli relies on it)
+
+**Failure mode.** If you upgrade without flipping the env var and your collector is plaintext, traces silently stop arriving (the gRPC connect fails). You'll see periodic `ERROR` logs from the OTLP exporter; metrics-based "is tracing flowing" alerting will go red.
+
+---
+
+## Logs JSON by default
+
+**What changed.** `STROMBOLI_LOG_FORMAT` defaults to `json`. Each log line is a single JSON object instead of human-readable text.
+
+**Why.** Most log aggregators (Loki, CloudWatch Logs, Datadog) parse JSON natively. Plain text required fragile regex parsers that broke when message format changed. JSON is the right default for operators; humans get the opt-out.
+
+**Migration.**
+
+If you tail logs by hand and want them readable:
+
+```bash
+export STROMBOLI_LOG_FORMAT=text
+```
+
+If your aggregator was already auto-detecting / regex-parsing the old format, switch its parser to JSON. This is usually a one-line config change.
+
+**Bonus: log level is now configurable.** `STROMBOLI_LOG_LEVEL` accepts `debug` / `info` / `warn` / `error`. Defaults to `info`.
+
+```bash
+export STROMBOLI_LOG_LEVEL=debug   # see every podman invocation, every config decision
+```
+
+---
+
+## Windows binaries dropped
+
+**What changed.** `v0.5.0-alpha` no longer publishes a `stromboli-windows-amd64.exe` artifact in the GitHub release. The matrix is now `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`.
+
+**Why.** Persistent agents (the marquee feature this release) use Unix-only syscalls — process groups via `SysProcAttr.Setpgid`, signal delivery via `syscall.Kill`. There's no clean Windows equivalent without job-object plumbing nobody asked for.
+
+Stromboli is also fundamentally Linux-bound at the orchestration layer: it speaks to a Podman Unix socket. Even if the binary linked, you couldn't usefully run it as a Windows host.
+
+**Migration.** Run Stromboli inside a Linux container (the published `ghcr.io/tomblancdev/stromboli` image), or via WSL2 on a Windows workstation.
+
+---
+
+## New env vars to be aware of
+
+These are not breaking — defaults preserve existing behavior — but they unlock features you may want to enable.
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `STROMBOLI_WEBHOOK_SIGNING_SECRET` | (none) | Sign outgoing async-job webhooks with HMAC-SHA256 so receivers can verify authenticity. See [webhook security](../guides/webhook-security.md). |
+| `STROMBOLI_RATE_LIMIT_TRUSTED_PROXIES` | (none) | CIDRs whose `X-Forwarded-For` header should be honored for rate-limit identity. Required if you're behind a reverse proxy. |
+| `STROMBOLI_AUTH_BLACKLIST_BACKEND` | `memory` | `memory` (default) or `bolt` for token blacklist storage. `bolt` survives restarts. |
+| `STROMBOLI_AUTH_BLACKLIST_BOLT_PATH` | `.stromboli/blacklist.db` | File path when `BACKEND=bolt`. |
+| `STROMBOLI_AUTH_BLACKLIST_CLEANUP_INTERVAL` | `1h` | How often expired entries are reaped. |
+
+For each, the [configuration reference](configuration.md) has the full table.
+
+## Sanity check after upgrading
+
+After restarting the server, hit a few endpoints to confirm:
+
+```bash
+# Health (should always work, no auth required)
+curl http://localhost:8080/health
+
+# Get a token (proves auth is wired correctly)
+curl -X POST http://localhost:8080/auth/token \
+  -H "Authorization: Bearer $STROMBOLI_API_TOKEN" \
+  -d '{"client_id": "smoke-test"}'
+
+# Metrics (on the new port)
+curl http://127.0.0.1:9090/metrics | head -3
+
+# Persistent agent (new in 0.5.0)
+curl -X POST http://localhost:8080/agents \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "hello", "claude": {"model": "sonnet"}}'
+```
+
+If all four return what you expect, you're good. If anything's off, the [troubleshooting guide](../self-hosting/troubleshooting.md) has common upgrade snags.
+
+## See also
+
+- [Full v0.5.0-alpha changelog](../changelog.md#050-alpha---2026-05-01)
+- [Configuration reference](configuration.md) — every env var, including the new ones
+- [Production hardening checklist](../security/production.md) — has been updated for v0.5.0
+- [Persistent agents guide](../guides/persistent-agents.md) — the headline new feature
+- [Webhook security](../guides/webhook-security.md) — how to verify signed callbacks

--- a/docs/security/production.md
+++ b/docs/security/production.md
@@ -2,31 +2,41 @@
 
 A checklist-driven guide to deploying Stromboli safely in production.
 
+!!! info "Upgrading from v0.4.x?"
+    v0.5.0-alpha changed several defaults to the secure side (auth on, tracing TLS on, metrics on a separate localhost listener, JSON logs). Read the [v0.5.0 upgrade guide](../getting-started/upgrade-to-0.5.0.md) before bouncing the server — a few of those defaults can fail-fast at startup if you're not ready.
+
 ## Required checklist
 
 These are non-negotiable for any production deployment:
 
-- [ ] **Enable authentication** — `STROMBOLI_AUTH_ENABLED=true`
-- [ ] **Set a strong JWT secret** — `STROMBOLI_JWT_SECRET=$(openssl rand -base64 32)`
+- [ ] **Set a strong JWT secret** — `STROMBOLI_JWT_SECRET=$(openssl rand -base64 32)`. Auth is on by default in v0.5.0+; the server fails fast at startup without a real secret.
 - [ ] **Enable TLS** — Use a reverse proxy with HTTPS (see below)
 - [ ] **Enable rate limiting** — `STROMBOLI_RATE_LIMIT_ENABLED=true`
+- [ ] **Configure trusted proxies** — `STROMBOLI_RATE_LIMIT_TRUSTED_PROXIES=10.0.0.0/8` (or your actual proxy CIDR). Without this, rate-limit identity can be spoofed via `X-Forwarded-For` from the public internet.
 - [ ] **Set volume allowlist** — `STROMBOLI_AGENT_ALLOWED_VOLUMES=/path1,/path2`
 - [ ] **Use rootless Podman** — `systemctl --user enable --now podman.socket`
 - [ ] **Set image allowlist** — `STROMBOLI_AGENT_ALLOWED_IMAGE_PATTERNS=python:*,node:*`
+- [ ] **Sign outgoing webhooks** — `STROMBOLI_WEBHOOK_SIGNING_SECRET=$(openssl rand -base64 32)` if any deployment uses `webhook_url`. Receivers MUST verify or you have a forgery vulnerability.
+- [ ] **Verify metrics binding** — `/metrics` defaults to `127.0.0.1:9090` on its own listener. Don't override to `0.0.0.0:9090` without a NetworkPolicy.
+- [ ] **Verify tracing TLS** — `STROMBOLI_TRACING_INSECURE` defaults to `false`. Only flip to `true` for localhost collectors.
 
 !!! danger "Volume security"
     **Never** set `STROMBOLI_AGENT_ALLOW_ALL_VOLUMES=true` in production. This disables all volume validation.
 
+!!! danger "Auth opt-out"
+    **Never** set `STROMBOLI_AUTH_ENABLED=false` in production. The fail-fast JWT-secret check is the gate that keeps a misconfigured deploy from accidentally exposing an unauthenticated API.
+
 ## Recommended checklist
 
 - [ ] Set resource limits (memory, CPU, timeout)
-- [ ] Enable monitoring (Prometheus metrics, structured logging)
-- [ ] Set up alerting (error rates, rate limit hits)
+- [ ] Enable monitoring (Prometheus metrics on the localhost listener, JSON logs)
+- [ ] Set up alerting (error rates, rate limit hits, blacklist backend failures returning 503)
 - [ ] Pin image versions (avoid `:latest` in production)
-- [ ] Back up session data
-- [ ] Restrict network access to `/metrics` and `/health`
+- [ ] Back up session data **and** the bolt blacklist file (if used)
 - [ ] Configure compose security (all `allow_*: false`)
-- [ ] Rotate JWT secrets periodically
+- [ ] Rotate JWT secrets periodically — on rotation, every active session is invalidated
+- [ ] Pick a token blacklist backend deliberately (memory vs. bolt — see below)
+- [ ] Tail JSON logs into your aggregator with the `STROMBOLI_*` field structure
 
 ## TLS setup
 
@@ -162,19 +172,75 @@ Pin to specific versions and use rolling updates:
 ```yaml
 services:
   stromboli:
-    image: ghcr.io/tomblancdev/stromboli:v0.3.0-alpha
+    image: ghcr.io/tomblancdev/stromboli:v0.5.0-alpha
 ```
 
 ```bash
 docker compose pull && docker compose up -d --no-deps stromboli
 ```
 
+When upgrading across a minor version (e.g. 0.4.x → 0.5.0), read the matching upgrade guide first — defaults sometimes flip in ways that fail-fast at startup. The [v0.5.0 upgrade guide](../getting-started/upgrade-to-0.5.0.md) is the playbook for the most recent jump.
+
+## Token blacklist: choose a backend
+
+Logout (`POST /auth/logout`) adds the token's JTI to a blacklist so the JWT is rejected on subsequent requests. Stromboli ships two storage backends; pick deliberately:
+
+| Backend | Survives restart? | Multi-process safe? | Best for |
+|---|---|---|---|
+| `memory` (default) | ❌ | ❌ | Single-instance deployments with short access-token TTLs (e.g. 1h) — the practical impact of "logout doesn't survive restart" is bounded. |
+| `bolt` | ✅ | ❌ | Single-instance deployments where logout MUST survive restart. Backed by a single file (`STROMBOLI_AUTH_BLACKLIST_BOLT_PATH`). Back this file up alongside session data. |
+
+Configure via:
+
+```bash
+export STROMBOLI_AUTH_BLACKLIST_BACKEND=bolt
+export STROMBOLI_AUTH_BLACKLIST_BOLT_PATH=/var/lib/stromboli/blacklist.db
+export STROMBOLI_AUTH_BLACKLIST_CLEANUP_INTERVAL=1h
+```
+
+Neither backend is multi-process safe yet — if you horizontally scale Stromboli (multiple replicas behind a load balancer), each replica has its own blacklist and a logout on one won't be visible to peers. For now, either accept that limitation (a logged-out token continues working until natural expiry on other replicas) or pin per-tenant traffic via session affinity. A shared backend (Redis) is the next planned iteration.
+
+The auth middleware **fails closed** on backend errors: a bolt I/O failure returns `503 auth backend unavailable` rather than admitting the request. Alert on this status code — sustained 503s mean the blacklist file is unreachable.
+
+## Webhook signing
+
+If your deployment uses `webhook_url` on `/run/async`, configure signing:
+
+```bash
+export STROMBOLI_WEBHOOK_SIGNING_SECRET="$(openssl rand -base64 32)"
+```
+
+Every outgoing callback then carries `X-Stromboli-Signature` (`sha256=<hex>`) and `X-Stromboli-Timestamp` headers. Receivers verify with HMAC-SHA256 over `timestamp + "." + body` and a freshness window. See the [webhook security guide](../guides/webhook-security.md) for receiver-side code in Go / Python / Node.
+
+If you forget to set the secret, Stromboli logs a loud `WARN` on startup so the missing config is visible. **Don't ignore it in production** — unsigned webhooks are forgeable by anyone who can guess the receiver URL.
+
+## Rate limiting and X-Forwarded-For
+
+Stromboli's rate limiter buckets per client IP. If you sit Stromboli behind a reverse proxy (Caddy, Nginx, an LB) without configuring trusted proxies, every request looks like it came from the proxy's IP — your per-IP rate limit becomes a per-cluster rate limit.
+
+Configure the trusted-proxy CIDR(s):
+
+```bash
+# Single proxy
+export STROMBOLI_RATE_LIMIT_TRUSTED_PROXIES="10.0.0.5/32"
+
+# Whole private network
+export STROMBOLI_RATE_LIMIT_TRUSTED_PROXIES="10.0.0.0/8,172.16.0.0/12"
+```
+
+When the request's immediate peer is in the allowlist, the leftmost `X-Forwarded-For` entry becomes the bucket key. From any other source, forwarding headers are ignored (the immediate peer is used).
+
+!!! danger "Don't allow 0.0.0.0/0"
+    Listing `0.0.0.0/0` in `TRUSTED_PROXIES` is the same as having no allowlist at all — anyone can spoof their bucket via a crafted `X-Forwarded-For` header. List only the actual CIDRs your proxy sits in.
+
 ## Operational security checklist
 
 - [ ] Rotate JWT secrets periodically
 - [ ] Rotate Claude API credentials as needed
-- [ ] Monitor for failed authentication attempts
+- [ ] Monitor for failed authentication attempts (`401`)
+- [ ] Monitor for blacklist backend failures (`503 auth backend unavailable`)
+- [ ] Monitor for sustained `429` rate-limit responses (potential abuse OR misconfigured trusted proxies)
 - [ ] Review container images for vulnerabilities
 - [ ] Keep Podman and host OS updated
-- [ ] Implement log retention policy
+- [ ] Implement log retention policy on the JSON log stream
 - [ ] Set up alerting for anomalous activity

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
     - Quick Start: getting-started/quickstart.md
     - Installation: getting-started/installation.md
     - Configuration: getting-started/configuration.md
+    - Upgrade to v0.5.0: getting-started/upgrade-to-0.5.0.md
   - Guides:
     - Running Agents: guides/running-agents.md
     - Persistent Agents: guides/persistent-agents.md


### PR DESCRIPTION
## Summary

Two follow-ups to #97 (feature guides), batched together because they tell the same story: what changed in v0.5.0 and how to operate it safely. Targeted at the next minor release.

## New: \`docs/getting-started/upgrade-to-0.5.0.md\`

Migration playbook for operators upgrading from v0.4.x:

- **TL;DR checklist** for the four operationally-breaking default changes (auth on, metrics on localhost, tracing TLS, JSON logs)
- **Per-change deep-dives** with the same structure: what / why / migration / verify / opt-out (where applicable)
- **Dropped Windows binaries** — explains why and points operators at WSL2 / Linux containers
- **New env vars** table with pointers to the deeper guides for webhook signing, trusted proxies, blacklist backend
- **Sanity-check curl sequence** to confirm a successful upgrade

This page becomes the canonical \"I'm running 0.4.x and want to update\" doc — operators no longer have to assemble the picture from changelog + configuration table + scattered guides.

## Updated: \`docs/security/production.md\`

The hardening checklist hadn't been touched in a few releases. Refreshed to v0.5.0 reality:

### Required-checklist updates

- JWT secret callout now mentions the fail-fast startup gate (auth is on by default; missing secret = boot failure, not silent vulnerability)
- **Trusted proxies** added — without it, rate-limit identity is spoofable behind any proxy
- **Webhook signing** added — without it, async callbacks are forgeable
- Metrics-on-localhost and tracing-TLS **verification** steps added (so an upgrader confirms the new defaults are in effect)
- New \"Auth opt-out\" danger callout, mirroring the existing volume one — \`STROMBOLI_AUTH_ENABLED=false\` in prod is the same class of footgun as \`ALLOW_ALL_VOLUMES=true\`

### New full sections

- **Token blacklist: choose a backend** — memory vs. bolt trade-off, fail-closed semantics on backend errors, multi-process limitation that justifies a future Redis backend
- **Webhook signing** — links to the receiver-verification guide, explains the loud-WARN-on-missing semantic
- **Rate limiting and X-Forwarded-For** — explains why a trusted-proxy CIDR is required behind any reverse proxy, with a danger callout against the \`0.0.0.0/0\` anti-pattern

### Operational checklist polish

- New alert targets: 503 from blacklist (= bolt I/O failure), sustained 429s (= abuse OR misconfigured trusted proxies)
- Pinned-version example bumped from \`v0.3.0-alpha\` to \`v0.5.0-alpha\` with a one-line nudge to read the upgrade guide on minor bumps

## Updated: \`mkdocs.yml\`

Adds the upgrade guide under \"Getting Started\".

## Test plan

- [ ] \`mkdocs serve\` and verify the upgrade guide renders, especially the long Mermaid-free admonitions / tables
- [ ] Click through the cross-links: upgrade guide → webhook security guide → persistent agents → back to upgrade
- [ ] Confirm production.md still flows top-to-bottom — the new sections sit between TLS and HA / Backups
- [ ] CI green

## Open PR landscape

This is the third in a connected docs sequence. Order to merge:

1. ~~#97 docs/feature-guides~~ — three new guides (persistent-agents, performance-tuning, webhook-security)
2. **This PR** — upgrade guide + production hardening refresh, depends on #97 for cross-links
3. ~~#96 refactor/openapi-typed-bodies~~ — independent, code-side typing fix; can land in any order

🤖 Generated with [Claude Code](https://claude.com/claude-code)