### PR TITLE
fix(agent): unbreak persistent agents — 5 lifecycle bugs + thread Claude opts

### DIFF
--- a/cmd/stromboli/main.go
+++ b/cmd/stromboli/main.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -45,6 +46,7 @@ import (
 	"stromboli/internal/runner"
 	"stromboli/internal/secrets"
 	"stromboli/internal/tracing"
+	"stromboli/internal/types"
 	"stromboli/internal/version"
 )
 
@@ -56,37 +58,94 @@ const defaultHealthTimeout = 5 * time.Second
 // The closure is invoked once per /agents create and produces the podman +
 // claude argv that the agent.Spawner will exec.
 //
-// MVP scope: single image, claude with stream-json I/O, sessions mounted at
-// /app/sessions, credentials at /home/stromboli/.claude/.credentials.json
-// (matching the production compose template). Custom images, allowed-volumes,
-// etc. land in a follow-up — see PR description.
+// The argv layout is shared with the regular /run runner via
+// claude.ApplyOptions and claude.EnvVars — when a caller sends `claude.model`
+// or `claude.allowed_tools` to /agents, those translate to the same flags
+// /run honors. Three things are pinned and not user-overridable: input/output
+// format (stream-json), include_partial_messages, and verbose — together
+// they're the contract the agent's stdout-line dispatcher relies on.
 func buildAgentArgv(agentImage, credentialsFile, sessionsDir string) agent.ArgvBuilder {
 	return func(req agent.CreateRequest, agentID, sessionID string) ([]string, error) {
+		// Pre-create the per-session bind-mount source. Podman's `-v` requires
+		// the host path to exist before mount — without this, the spawner
+		// dies with `statfs ...: no such file or directory` and the agent
+		// transitions straight to StatusExited with `signal: killed` from
+		// cmd.Wait, which gives operators almost nothing to debug from.
+		// Mode 0700: only the runtime user reads sessions; matches the
+		// existing /run runner's session-dir creation.
+		sessionDir := filepath.Join(sessionsDir, sessionID)
+		if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+			return nil, fmt.Errorf("create session dir %q: %w", sessionDir, err)
+		}
+
 		// Container name doubles as the bookkeeping handle so a kill -9 of
 		// stromboli leaves a discoverable orphan that cleanup can reap.
 		containerName := "stromboli-" + agentID
 
-		argv := []string{
+		// Map the host user into the container and preserve their UID. Without
+		// this the container runs as root, and claude refuses
+		// --dangerously-skip-permissions when running as root. The regular
+		// /run runner does the same dance via podman.CommandBuilder.WithKeepID.
+		hostUser := fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
+
+		// ----- podman flags -----
+		podmanArgs := []string{
 			"podman", "run",
 			"--rm",
-			"--interactive",                   // keep stdin open for stream-json input
+			"--interactive", // keep stdin open for stream-json input
 			"--name", containerName,
+			"--userns=keep-id", // map host UID/GID into container
+			"--user", hostUser, // run claude as the host user
 			"-e", "HOME=/home/user",
 			"-v", credentialsFile + ":/home/user/.claude/.credentials.json:ro",
-			"-v", sessionsDir + "/" + sessionID + ":/home/user",
-			agentImage,
-			"--input-format", "stream-json",
-			"--output-format", "stream-json",
-			"--include-partial-messages",
-			"--session-id", sessionID,
+			"-v", sessionDir + ":/home/user",
 		}
+		// Per-request env vars (prompt cache TTL, Bedrock tier, PowerShell tool).
+		podmanArgs = append(podmanArgs, claude.EnvVars(opts(req))...)
 		if req.Workdir != "" {
-			// Insert -w just before the image arg.
-			imgIdx := len(argv) - 7 // 7 args after the image
-			argv = append(argv[:imgIdx], append([]string{"-w", req.Workdir}, argv[imgIdx:]...)...)
+			podmanArgs = append(podmanArgs, "-w", req.Workdir)
 		}
+		podmanArgs = append(podmanArgs, agentImage)
+
+		// ----- claude flags -----
+		// The agent image's entrypoint (docker-entrypoint.sh) execs its first
+		// positional arg as the binary; we name "claude" explicitly so the
+		// rest of the flags reach the Claude CLI rather than node (the image
+		// default). Same prepend pattern the regular /run runner uses.
+		//
+		// Build via claude.NewCommandBuilder so user-supplied options
+		// (model, effort, system_prompt, allowed_tools, etc.) are honored
+		// the same way they are for /run.
+		cb := claude.NewCommandBuilder().
+			WithSessionID(sessionID).
+			WithInputFormat("stream-json").
+			WithOutputFormat("stream-json").
+			WithIncludePartialMessages().
+			WithVerbose() // required by claude when output-format=stream-json
+		claude.ApplyOptions(cb, opts(req))
+
+		// ApplyOptions may have flipped these from user input — restore the
+		// agent-required values. Stream-json on stdin/stdout is how the
+		// dispatcher reads agent events; flipping output to "text" would
+		// silently break every subscriber.
+		cb.WithInputFormat("stream-json")
+		cb.WithOutputFormat("stream-json")
+
+		argv := append(podmanArgs, "claude")
+		argv = append(argv, cb.Build()...)
 		return argv, nil
 	}
+}
+
+// opts unpacks the optional Claude options on a CreateRequest into a value
+// safe for ApplyOptions / EnvVars to consume. Callers pass `req.Claude` as a
+// pointer so the JSON shape is `claude: { ... }` rather than a freeform
+// object — but the helper APIs want the value directly.
+func opts(req agent.CreateRequest) types.ClaudeOptions {
+	if req.Claude == nil {
+		return types.ClaudeOptions{}
+	}
+	return *req.Claude
 }
 
 // buildBlacklist constructs the configured Blacklist backend, starts its

--- a/cmd/stromboli/main_test.go
+++ b/cmd/stromboli/main_test.go
@@ -2,14 +2,211 @@ package main
 
 import (
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"stromboli/internal/agent"
+	"stromboli/internal/types"
 )
+
+// indexOf returns the position of want in args, or -1 if not present.
+func indexOf(args []string, want string) int {
+	for i, a := range args {
+		if a == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// hasContiguous reports whether the given subsequence appears in args.
+func hasContiguous(args []string, want ...string) bool {
+	for i := 0; i+len(want) <= len(args); i++ {
+		match := true
+		for j, w := range want {
+			if args[i+j] != w {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// findArgvImage returns the index of the agent image in argv. The image is
+// the first non-flag arg after `podman run` and our flag block; identifiers
+// of the form ghcr.io/... or local-name:tag are matched here.
+func findArgvImage(args []string, image string) int {
+	for i, a := range args {
+		if a == image {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestBuildAgentArgv_RejectsCannotCreateSessionDir(t *testing.T) {
+	// sessionsDir under a path that exists as a regular file → MkdirAll fails.
+	tmp := t.TempDir()
+	blocker := filepath.Join(tmp, "iam-a-file")
+	require.NoError(t, os.WriteFile(blocker, []byte{}, 0o600))
+
+	build := buildAgentArgv("img:latest", "/tmp/creds", filepath.Join(blocker, "sessions"))
+	_, err := build(agent.CreateRequest{}, "agent-x", "session-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create session dir")
+}
+
+func TestBuildAgentArgv_BasicShape(t *testing.T) {
+	sessions := t.TempDir()
+	build := buildAgentArgv("ghcr.io/example/stromboli-agent:test", "/host/creds.json", sessions)
+
+	args, err := build(agent.CreateRequest{}, "agent-abc", "8e29f4d2-aaaa-bbbb-cccc-1234567890ab")
+	require.NoError(t, err)
+
+	// Bug #1 regression: session dir must be created on disk.
+	sessionDir := filepath.Join(sessions, "8e29f4d2-aaaa-bbbb-cccc-1234567890ab")
+	info, statErr := os.Stat(sessionDir)
+	require.NoError(t, statErr, "buildAgentArgv must pre-create the session subdirectory")
+	assert.True(t, info.IsDir())
+
+	// Bug #3 regression: "claude" must be prepended to the in-container args
+	// (the agent image's entrypoint defaults to node).
+	assert.Contains(t, args, "claude", "argv must name claude as the in-container binary")
+
+	// Bug #4 regression: --userns=keep-id and --user $UID:$GID are required
+	// or claude refuses dangerously-skip-permissions for the root container user.
+	assert.Contains(t, args, "--userns=keep-id")
+	userIdx := indexOf(args, "--user")
+	require.GreaterOrEqual(t, userIdx, 0, "--user flag must be present")
+	require.Less(t, userIdx, len(args)-1, "--user must have a value")
+	assert.Regexp(t, `^\d+:\d+$`, args[userIdx+1], "--user must be UID:GID, got %q", args[userIdx+1])
+
+	// Bug #5 regression: stream-json output requires --verbose; without it
+	// claude exits 1 on the first turn.
+	assert.Contains(t, args, "--verbose")
+
+	// Stream-json contract that the dispatcher relies on; both directions.
+	assert.True(t, hasContiguous(args, "--input-format", "stream-json"))
+	assert.True(t, hasContiguous(args, "--output-format", "stream-json"))
+	assert.Contains(t, args, "--include-partial-messages")
+
+	// Session ID must thread through to the claude flag.
+	assert.True(t, hasContiguous(args, "--session-id", "8e29f4d2-aaaa-bbbb-cccc-1234567890ab"))
+}
+
+func TestBuildAgentArgv_ThreadsClaudeOptionsThrough(t *testing.T) {
+	// Bug #6 regression: req.Claude was parsed but ignored. Operators sending
+	// `claude.model` to /agents got the CLI's default model instead.
+	sessions := t.TempDir()
+	build := buildAgentArgv("img:latest", "/creds", sessions)
+
+	args, err := build(agent.CreateRequest{
+		Claude: &types.ClaudeOptions{
+			Model:                      "sonnet",
+			Effort:                     "high",
+			SystemPrompt:               "Custom system prompt",
+			AllowedTools:               []string{"Read", "Bash"},
+			DangerouslySkipPermissions: true,
+		},
+	}, "agent-x", "00000000-0000-0000-0000-000000000001")
+	require.NoError(t, err)
+
+	assert.True(t, hasContiguous(args, "--model", "sonnet"), "argv=%v", args)
+	assert.True(t, hasContiguous(args, "--effort", "high"))
+	assert.True(t, hasContiguous(args, "--system-prompt", "Custom system prompt"))
+	assert.Contains(t, args, "--dangerously-skip-permissions")
+}
+
+func TestBuildAgentArgv_ThreadsEnvVarOnlyOptions(t *testing.T) {
+	// Bug #6 regression continued: env-var-only options
+	// (prompt_caching_ttl, bedrock_service_tier, enable_powershell_tool)
+	// were dropped on the floor for /agents. Verify they reach podman -e.
+	sessions := t.TempDir()
+	build := buildAgentArgv("img:latest", "/creds", sessions)
+
+	args, err := build(agent.CreateRequest{
+		Claude: &types.ClaudeOptions{
+			PromptCachingTTL:     "1h",
+			BedrockServiceTier:   "priority",
+			EnablePowerShellTool: true,
+		},
+	}, "agent-x", "00000000-0000-0000-0000-000000000002")
+	require.NoError(t, err)
+
+	assert.True(t, hasContiguous(args, "-e", "ENABLE_PROMPT_CACHING_1H=1"))
+	assert.True(t, hasContiguous(args, "-e", "ANTHROPIC_BEDROCK_SERVICE_TIER=priority"))
+	assert.True(t, hasContiguous(args, "-e", "CLAUDE_CODE_USE_POWERSHELL_TOOL=1"))
+}
+
+func TestBuildAgentArgv_ForcesStreamJsonEvenIfUserOverrides(t *testing.T) {
+	// The dispatcher in internal/agent reads stdout one JSON-line per event;
+	// flipping output to "text" or "json" would silently break every
+	// subscriber. The agent always pins these regardless of the user's input.
+	sessions := t.TempDir()
+	build := buildAgentArgv("img:latest", "/creds", sessions)
+
+	args, err := build(agent.CreateRequest{
+		Claude: &types.ClaudeOptions{
+			InputFormat:  "text",
+			OutputFormat: "json",
+		},
+	}, "agent-x", "00000000-0000-0000-0000-000000000003")
+	require.NoError(t, err)
+
+	// Last value of each flag wins on the claude CLI; we re-set them after
+	// ApplyOptions so user values can't override.
+	// Count occurrences and ensure the LAST one is stream-json.
+	lastInputFormat := ""
+	lastOutputFormat := ""
+	for i, a := range args {
+		if i+1 >= len(args) {
+			break
+		}
+		if a == "--input-format" {
+			lastInputFormat = args[i+1]
+		}
+		if a == "--output-format" {
+			lastOutputFormat = args[i+1]
+		}
+	}
+	assert.Equal(t, "stream-json", lastInputFormat,
+		"last --input-format value wins; agent must pin stream-json")
+	assert.Equal(t, "stream-json", lastOutputFormat,
+		"last --output-format value wins; agent must pin stream-json")
+}
+
+func TestBuildAgentArgv_WorkdirIsPodmanDashW(t *testing.T) {
+	// -w is a podman flag, NOT a claude flag — it sets the container's
+	// working directory. Used to be a sed-style insert "before the image";
+	// now appended explicitly so order isn't fragile.
+	sessions := t.TempDir()
+	build := buildAgentArgv("ghcr.io/example/stromboli-agent:test", "/creds", sessions)
+
+	args, err := build(agent.CreateRequest{Workdir: "/workspace"}, "agent-x", "00000000-0000-0000-0000-000000000004")
+	require.NoError(t, err)
+
+	wIdx := indexOf(args, "-w")
+	require.GreaterOrEqual(t, wIdx, 0, "-w must be present when Workdir is set")
+	assert.Equal(t, "/workspace", args[wIdx+1])
+
+	// -w must come BEFORE the image name (it's a podman flag).
+	imgIdx := findArgvImage(args, "ghcr.io/example/stromboli-agent:test")
+	require.GreaterOrEqual(t, imgIdx, 0, "image must appear in argv")
+	assert.Less(t, wIdx, imgIdx, "-w is a podman flag and must precede the image")
+}
 
 func TestParseLogLevel(t *testing.T) {
 	cases := []struct {
-		in    string
-		want  slog.Level
-		ok    bool
+		in   string
+		want slog.Level
+		ok   bool
 	}{
 		{"", slog.LevelInfo, true},
 		{"info", slog.LevelInfo, true},

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -94,7 +94,13 @@ func (m *Manager) Create(ctx context.Context, req CreateRequest, build ArgvBuild
 	// lines per second during tool calls.
 	lineSink := make(chan string, 256)
 
-	proc, err := m.spawner.Spawn(ctx, SpawnRequest{
+	// The agent's process must outlive the HTTP request that spawned it —
+	// using `ctx` here would bind the underlying podman/claude process to
+	// `c.Request.Context()`, which gets cancelled the instant the handler
+	// returns 201 Created. exec.CommandContext would then SIGKILL the child
+	// and the agent would die before the caller's first /send arrives. Use
+	// Background instead; lifecycle is managed by Stop / StopAll / watchIdle.
+	proc, err := m.spawner.Spawn(context.Background(), SpawnRequest{
 		AgentID:   agentID,
 		SessionID: sessionID,
 		Workdir:   req.Workdir,

--- a/internal/claude/options.go
+++ b/internal/claude/options.go
@@ -1,0 +1,188 @@
+package claude
+
+import (
+	"stromboli/internal/types"
+)
+
+// ApplyOptions threads a fully-typed types.ClaudeOptions struct onto a
+// CommandBuilder. Empty / zero-value fields leave the builder untouched, so
+// callers can chain caller-specific overrides before or after this call.
+//
+// The split of responsibilities:
+//
+//   - This function handles every option that maps to a `--flag` argument.
+//   - EnvVars (below) handles the env-var-only options
+//     (prompt_caching_ttl, bedrock_service_tier, enable_powershell_tool)
+//     because those are passed via `podman -e KEY=VALUE`, not on the
+//     claude command line.
+//
+// Both runner.PodmanRunner (for /run, /run/async, /run/stream) and
+// main.buildAgentArgv (for /agents) call into these so the surface stays
+// consistent across the two execution paths. The previous duplication —
+// where /agents simply ignored req.Claude — is what shipped untested in
+// v0.5.0; consolidating here is the regression net.
+//
+// SessionID is intentionally NOT applied here: callers control session
+// lifecycle and decide whether to use --session-id (new) or --resume
+// (existing) via the surrounding context.
+func ApplyOptions(b *CommandBuilder, opts types.ClaudeOptions) *CommandBuilder {
+	applySessionOptions(b, opts)
+	applyModelOptions(b, opts)
+	applyPromptOptions(b, opts)
+	applyToolsOptions(b, opts)
+	applyPermissionOptions(b, opts)
+	applyIOOptions(b, opts)
+	applyResourceOptions(b, opts)
+	applyMiscOptions(b, opts)
+	return b
+}
+
+// EnvVars returns the podman `-e KEY=VALUE` flag pairs for the env-var-only
+// Claude options (prompt cache TTL, Bedrock service tier, PowerShell tool).
+// Empty / zero-value fields contribute nothing. Returns a fresh slice every
+// call; safe for the caller to append onto.
+func EnvVars(opts types.ClaudeOptions) []string {
+	out := make([]string, 0, 6)
+	switch opts.PromptCachingTTL {
+	case "1h":
+		out = append(out, "-e", "ENABLE_PROMPT_CACHING_1H=1")
+	case "5m":
+		out = append(out, "-e", "FORCE_PROMPT_CACHING_5M=1")
+	}
+	if opts.BedrockServiceTier != "" {
+		out = append(out, "-e", "ANTHROPIC_BEDROCK_SERVICE_TIER="+opts.BedrockServiceTier)
+	}
+	if opts.EnablePowerShellTool {
+		out = append(out, "-e", "CLAUDE_CODE_USE_POWERSHELL_TOOL=1")
+	}
+	return out
+}
+
+// --- internal sub-appliers (one per option group; lifted verbatim from the
+// runner package for traceability — there's no behavioral change here).
+
+func applySessionOptions(b *CommandBuilder, opts types.ClaudeOptions) {
+	if opts.Continue {
+		b.WithContinue()
+	}
+	if opts.ForkSession {
+		b.WithForkSession()
+	}
+	if opts.NoPersistence {
+		b.WithNoSessionPersistence()
+	}
+}
+
+func applyModelOptions(b *CommandBuilder, opts types.ClaudeOptions) {
+	if opts.Model != "" {
+		b.WithModel(opts.Model)
+	}
+	if opts.FallbackModel != "" {
+		b.WithFallbackModel(opts.FallbackModel)
+	}
+	if opts.Effort != "" {
+		b.WithEffort(opts.Effort)
+	}
+}
+
+func applyPromptOptions(b *CommandBuilder, opts types.ClaudeOptions) {
+	if opts.SystemPrompt != "" {
+		b.WithSystemPrompt(opts.SystemPrompt)
+	}
+	if opts.AppendSystemPrompt != "" {
+		b.WithAppendSystemPrompt(opts.AppendSystemPrompt)
+	}
+}
+
+func applyToolsOptions(b *CommandBuilder, opts types.ClaudeOptions) {
+	if len(opts.Tools) > 0 {
+		b.WithTools(opts.Tools...)
+	}
+	if len(opts.AllowedTools) > 0 {
+		b.WithAllowedTools(opts.AllowedTools...)
+	}
+	if len(opts.DisallowedTools) > 0 {
+		b.WithDisallowedTools(opts.DisallowedTools...)
+	}
+}
+
+func applyPermissionOptions(b *CommandBuilder, opts types.ClaudeOptions) {
+	if opts.PermissionMode != "" {
+		b.WithPermissionMode(opts.PermissionMode)
+	}
+	if opts.DangerouslySkipPermissions {
+		b.WithDangerouslySkipPermissions()
+	}
+	if opts.AllowDangerouslySkipPermissions {
+		b.WithAllowDangerouslySkipPermissions()
+	}
+}
+
+func applyIOOptions(b *CommandBuilder, opts types.ClaudeOptions) {
+	if opts.InputFormat != "" {
+		b.WithInputFormat(opts.InputFormat)
+	}
+	if opts.OutputFormat != "" {
+		b.WithOutputFormat(opts.OutputFormat)
+	}
+	if opts.IncludePartialMessages {
+		b.WithIncludePartialMessages()
+	}
+	if opts.ReplayUserMessages {
+		b.WithReplayUserMessages()
+	}
+	if opts.JSONSchema != "" {
+		b.WithJSONSchema(opts.JSONSchema)
+	}
+}
+
+func applyResourceOptions(b *CommandBuilder, opts types.ClaudeOptions) {
+	if opts.MaxBudgetUSD != nil {
+		b.WithMaxBudgetUSD(*opts.MaxBudgetUSD)
+	}
+	if opts.MaxTurns != nil {
+		b.WithMaxTurns(*opts.MaxTurns)
+	}
+	if len(opts.MCPConfigs) > 0 {
+		b.WithMCPConfig(opts.MCPConfigs...)
+	}
+	if opts.StrictMCPConfig {
+		b.WithStrictMCPConfig()
+	}
+	if opts.Agent != "" {
+		b.WithAgent(opts.Agent)
+	}
+	if opts.Agents != nil {
+		b.WithAgents(opts.Agents)
+	}
+	if len(opts.AddDirs) > 0 {
+		b.WithAddDir(opts.AddDirs...)
+	}
+	if len(opts.PluginDirs) > 0 {
+		b.WithPluginDir(opts.PluginDirs...)
+	}
+	if len(opts.Files) > 0 {
+		b.WithFiles(opts.Files...)
+	}
+	if opts.Settings != "" {
+		b.WithSettings(opts.Settings)
+	}
+	if len(opts.SettingSources) > 0 {
+		b.WithSettingSources(opts.SettingSources...)
+	}
+	if len(opts.Betas) > 0 {
+		b.WithBetas(opts.Betas...)
+	}
+}
+
+func applyMiscOptions(b *CommandBuilder, opts types.ClaudeOptions) {
+	if opts.Verbose {
+		b.WithVerbose()
+	}
+	if opts.Debug != "" {
+		b.WithDebug(opts.Debug)
+	}
+	if opts.DisableSlashCommands {
+		b.WithDisableSlashCommands()
+	}
+}

--- a/internal/claude/options_test.go
+++ b/internal/claude/options_test.go
@@ -1,0 +1,145 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"stromboli/internal/types"
+)
+
+// containsArg returns true if want appears as a contiguous run in args.
+// Avoids false positives when a value happens to equal a flag name.
+func containsArg(args []string, want ...string) bool {
+	if len(want) == 0 {
+		return true
+	}
+	for i := 0; i+len(want) <= len(args); i++ {
+		match := true
+		for j, w := range want {
+			if args[i+j] != w {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func TestApplyOptions_EmptyOptionsAddsNothing(t *testing.T) {
+	// Build the same builder twice: once with no ApplyOptions call, once
+	// with an empty struct passed through. The two outputs must match —
+	// empty / zero-value fields must not contribute any flags.
+	bare := NewCommandBuilder().Build()
+
+	b := NewCommandBuilder()
+	ApplyOptions(b, types.ClaudeOptions{})
+	withEmptyOpts := b.Build()
+
+	assert.Equal(t, bare, withEmptyOpts,
+		"empty options must produce the same argv as no ApplyOptions call")
+}
+
+func TestApplyOptions_ModelEffortAndPermissions(t *testing.T) {
+	b := NewCommandBuilder()
+	ApplyOptions(b, types.ClaudeOptions{
+		Model:                      "sonnet",
+		Effort:                     "high",
+		DangerouslySkipPermissions: true,
+	})
+	args := b.Build()
+
+	assert.True(t, containsArg(args, "--model", "sonnet"))
+	assert.True(t, containsArg(args, "--effort", "high"))
+	assert.True(t, containsArg(args, "--dangerously-skip-permissions"))
+}
+
+func TestApplyOptions_ToolsLists(t *testing.T) {
+	b := NewCommandBuilder()
+	ApplyOptions(b, types.ClaudeOptions{
+		AllowedTools:    []string{"Read", "Bash"},
+		DisallowedTools: []string{"Write"},
+	})
+	args := b.Build()
+
+	// AllowedTools is comma-joined into one --allowedTools value by the builder.
+	assert.True(t, containsArg(args, "--allowedTools"), "expected --allowedTools flag, got %v", args)
+	assert.True(t, containsArg(args, "--disallowedTools"), "expected --disallowedTools flag, got %v", args)
+}
+
+func TestApplyOptions_SessionIDIsNotApplied(t *testing.T) {
+	// SessionID is the caller's responsibility (new vs resume distinction).
+	b := NewCommandBuilder()
+	ApplyOptions(b, types.ClaudeOptions{
+		SessionID: "abc123",
+	})
+	args := b.Build()
+	assert.False(t, containsArg(args, "--session-id"),
+		"ApplyOptions must NOT set --session-id; the caller controls session lifecycle")
+}
+
+func TestApplyOptions_BudgetAndTurnsRespectPointers(t *testing.T) {
+	budget := 5.5
+	turns := 30
+	b := NewCommandBuilder()
+	ApplyOptions(b, types.ClaudeOptions{
+		MaxBudgetUSD: &budget,
+		MaxTurns:     &turns,
+	})
+	args := b.Build()
+	assert.True(t, containsArg(args, "--max-budget-usd", "5.50"))
+	assert.True(t, containsArg(args, "--max-turns", "30"))
+}
+
+func TestEnvVars_PromptCachingTTL(t *testing.T) {
+	cases := []struct {
+		ttl      string
+		wantKV   string
+		wantNone bool
+	}{
+		{"5m", "FORCE_PROMPT_CACHING_5M=1", false},
+		{"1h", "ENABLE_PROMPT_CACHING_1H=1", false},
+		{"", "", true},
+		{"30m", "", true}, // only 5m and 1h are recognised; anything else is ignored
+	}
+	for _, tc := range cases {
+		t.Run(tc.ttl, func(t *testing.T) {
+			got := EnvVars(types.ClaudeOptions{PromptCachingTTL: tc.ttl})
+			if tc.wantNone {
+				assert.Empty(t, got, "unrecognised TTL %q must contribute no env vars", tc.ttl)
+				return
+			}
+			assert.Equal(t, []string{"-e", tc.wantKV}, got)
+		})
+	}
+}
+
+func TestEnvVars_BedrockServiceTier(t *testing.T) {
+	got := EnvVars(types.ClaudeOptions{BedrockServiceTier: "priority"})
+	assert.Equal(t, []string{"-e", "ANTHROPIC_BEDROCK_SERVICE_TIER=priority"}, got)
+}
+
+func TestEnvVars_PowerShellTool(t *testing.T) {
+	got := EnvVars(types.ClaudeOptions{EnablePowerShellTool: true})
+	assert.Equal(t, []string{"-e", "CLAUDE_CODE_USE_POWERSHELL_TOOL=1"}, got)
+}
+
+func TestEnvVars_AllAtOnce(t *testing.T) {
+	got := EnvVars(types.ClaudeOptions{
+		PromptCachingTTL:     "1h",
+		BedrockServiceTier:   "flex",
+		EnablePowerShellTool: true,
+	})
+	assert.Equal(t, []string{
+		"-e", "ENABLE_PROMPT_CACHING_1H=1",
+		"-e", "ANTHROPIC_BEDROCK_SERVICE_TIER=flex",
+		"-e", "CLAUDE_CODE_USE_POWERSHELL_TOOL=1",
+	}, got)
+}
+
+func TestEnvVars_EmptyReturnsEmptySlice(t *testing.T) {
+	got := EnvVars(types.ClaudeOptions{})
+	assert.Empty(t, got)
+}

--- a/internal/runner/compose.go
+++ b/internal/runner/compose.go
@@ -93,7 +93,7 @@ func (r *PodmanRunner) runWithCompose(ctx context.Context, req Request) (*Result
 	if req.Claude.Resume {
 		claudeBuilder.WithResume()
 	}
-	r.applyClaudeOptions(claudeBuilder, req.Claude)
+	claude.ApplyOptions(claudeBuilder, req.Claude)
 	claudeCmd := claudeBuilder.Build()
 
 	// Prepend "claude" if mounting CLI
@@ -223,7 +223,7 @@ func (r *PodmanRunner) runStreamWithCompose(ctx context.Context, req Request, ou
 	if req.Claude.Resume {
 		claudeBuilder.WithResume()
 	}
-	r.applyClaudeOptions(claudeBuilder, req.Claude)
+	claude.ApplyOptions(claudeBuilder, req.Claude)
 	claudeCmd := claudeBuilder.Build()
 
 	if r.mountClaudeCLI {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -42,10 +42,10 @@ type Runner interface {
 
 // Request contains the parameters for running Claude
 type Request struct {
-	Prompt    string
+	Prompt  string
 	Workdir string
-	Claude    types.ClaudeOptions
-	Podman    types.PodmanOptions
+	Claude  types.ClaudeOptions
+	Podman  types.PodmanOptions
 }
 
 // Result contains the output from running Claude
@@ -276,7 +276,7 @@ func (r *PodmanRunner) Run(ctx context.Context, req Request) (*Result, error) {
 	}
 
 	// Apply all other Claude options
-	r.applyClaudeOptions(claudeBuilder, req.Claude)
+	claude.ApplyOptions(claudeBuilder, req.Claude)
 
 	claudeCmd := claudeBuilder.Build()
 
@@ -481,7 +481,7 @@ func (r *PodmanRunner) RunStream(ctx context.Context, req Request, output chan<-
 	}
 
 	// Apply all other Claude options
-	r.applyClaudeOptions(claudeBuilder, req.Claude)
+	claude.ApplyOptions(claudeBuilder, req.Claude)
 
 	claudeCmd := claudeBuilder.Build()
 
@@ -736,18 +736,20 @@ func (r *PodmanRunner) applyRequestConfig(req Request, podmanBuilder *podman.Com
 // applyClaudeEnvVars translates Claude-side env-var-only options into podman
 // `-e KEY=VALUE` injections. Each option is opt-in — empty string / false
 // leaves the variable unset so the CLI sees its native default.
+//
+// The flag-pair format produced by claude.EnvVars (`-e KEY=VALUE`) is
+// converted here into the podman.CommandBuilder's WithEnv calls so the
+// existing builder API stays the same.
 func applyClaudeEnvVars(b *podman.CommandBuilder, opts types.ClaudeOptions) {
-	switch opts.PromptCachingTTL {
-	case "1h":
-		b.WithEnv("ENABLE_PROMPT_CACHING_1H", "1")
-	case "5m":
-		b.WithEnv("FORCE_PROMPT_CACHING_5M", "1")
-	}
-	if opts.BedrockServiceTier != "" {
-		b.WithEnv("ANTHROPIC_BEDROCK_SERVICE_TIER", opts.BedrockServiceTier)
-	}
-	if opts.EnablePowerShellTool {
-		b.WithEnv("CLAUDE_CODE_USE_POWERSHELL_TOOL", "1")
+	pairs := claude.EnvVars(opts)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		// pairs is [-e, K=V, -e, K=V, ...]; split each K=V on the first '='.
+		kv := pairs[i+1]
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		b.WithEnv(kv[:eq], kv[eq+1:])
 	}
 }
 
@@ -773,152 +775,10 @@ func (r *PodmanRunner) RunAsync(ctx context.Context, req Request, jobID string, 
 	}()
 }
 
-// applyClaudeOptions applies all Claude options to the builder
-func (r *PodmanRunner) applyClaudeOptions(b *claude.CommandBuilder, opts types.ClaudeOptions) {
-	// Note: SessionID is handled separately in Run()
-	r.applySessionOptions(b, opts)
-	r.applyModelOptions(b, opts)
-	r.applyPromptOptions(b, opts)
-	r.applyToolsOptions(b, opts)
-	r.applyPermissionOptions(b, opts)
-	r.applyIOOptions(b, opts)
-	r.applyResourceOptions(b, opts)
-	r.applyMiscOptions(b, opts)
-}
-
-// applySessionOptions handles Continue, ForkSession, NoPersistence options
-func (r *PodmanRunner) applySessionOptions(b *claude.CommandBuilder, opts types.ClaudeOptions) {
-	if opts.Continue {
-		b.WithContinue()
-	}
-	if opts.ForkSession {
-		b.WithForkSession()
-	}
-	if opts.NoPersistence {
-		b.WithNoSessionPersistence()
-	}
-}
-
-// applyModelOptions handles Model, FallbackModel, Effort options
-func (r *PodmanRunner) applyModelOptions(b *claude.CommandBuilder, opts types.ClaudeOptions) {
-	if opts.Model != "" {
-		b.WithModel(opts.Model)
-	}
-	if opts.FallbackModel != "" {
-		b.WithFallbackModel(opts.FallbackModel)
-	}
-	if opts.Effort != "" {
-		b.WithEffort(opts.Effort)
-	}
-}
-
-// applyPromptOptions handles SystemPrompt, AppendSystemPrompt options
-func (r *PodmanRunner) applyPromptOptions(b *claude.CommandBuilder, opts types.ClaudeOptions) {
-	if opts.SystemPrompt != "" {
-		b.WithSystemPrompt(opts.SystemPrompt)
-	}
-	if opts.AppendSystemPrompt != "" {
-		b.WithAppendSystemPrompt(opts.AppendSystemPrompt)
-	}
-}
-
-// applyToolsOptions handles Tools, AllowedTools, DisallowedTools options
-func (r *PodmanRunner) applyToolsOptions(b *claude.CommandBuilder, opts types.ClaudeOptions) {
-	if len(opts.Tools) > 0 {
-		b.WithTools(opts.Tools...)
-	}
-	if len(opts.AllowedTools) > 0 {
-		b.WithAllowedTools(opts.AllowedTools...)
-	}
-	if len(opts.DisallowedTools) > 0 {
-		b.WithDisallowedTools(opts.DisallowedTools...)
-	}
-}
-
-// applyPermissionOptions handles PermissionMode, DangerouslySkipPermissions, AllowDangerouslySkipPermissions options
-func (r *PodmanRunner) applyPermissionOptions(b *claude.CommandBuilder, opts types.ClaudeOptions) {
-	if opts.PermissionMode != "" {
-		b.WithPermissionMode(opts.PermissionMode)
-	}
-	if opts.DangerouslySkipPermissions {
-		b.WithDangerouslySkipPermissions()
-	}
-	if opts.AllowDangerouslySkipPermissions {
-		b.WithAllowDangerouslySkipPermissions()
-	}
-}
-
-// applyIOOptions handles InputFormat, OutputFormat, IncludePartialMessages, ReplayUserMessages, JSONSchema options
-func (r *PodmanRunner) applyIOOptions(b *claude.CommandBuilder, opts types.ClaudeOptions) {
-	if opts.InputFormat != "" {
-		b.WithInputFormat(opts.InputFormat)
-	}
-	if opts.OutputFormat != "" {
-		b.WithOutputFormat(opts.OutputFormat)
-	}
-	if opts.IncludePartialMessages {
-		b.WithIncludePartialMessages()
-	}
-	if opts.ReplayUserMessages {
-		b.WithReplayUserMessages()
-	}
-	if opts.JSONSchema != "" {
-		b.WithJSONSchema(opts.JSONSchema)
-	}
-}
-
-// applyResourceOptions handles MaxBudgetUSD, MCPConfigs, StrictMCPConfig, Agent, Agents, AddDirs, PluginDirs, Files, Settings, SettingSources, Betas options
-func (r *PodmanRunner) applyResourceOptions(b *claude.CommandBuilder, opts types.ClaudeOptions) {
-	if opts.MaxBudgetUSD != nil {
-		b.WithMaxBudgetUSD(*opts.MaxBudgetUSD)
-	}
-	if opts.MaxTurns != nil {
-		b.WithMaxTurns(*opts.MaxTurns)
-	}
-	if len(opts.MCPConfigs) > 0 {
-		b.WithMCPConfig(opts.MCPConfigs...)
-	}
-	if opts.StrictMCPConfig {
-		b.WithStrictMCPConfig()
-	}
-	if opts.Agent != "" {
-		b.WithAgent(opts.Agent)
-	}
-	if opts.Agents != nil {
-		b.WithAgents(opts.Agents)
-	}
-	if len(opts.AddDirs) > 0 {
-		b.WithAddDir(opts.AddDirs...)
-	}
-	if len(opts.PluginDirs) > 0 {
-		b.WithPluginDir(opts.PluginDirs...)
-	}
-	if len(opts.Files) > 0 {
-		b.WithFiles(opts.Files...)
-	}
-	if opts.Settings != "" {
-		b.WithSettings(opts.Settings)
-	}
-	if len(opts.SettingSources) > 0 {
-		b.WithSettingSources(opts.SettingSources...)
-	}
-	if len(opts.Betas) > 0 {
-		b.WithBetas(opts.Betas...)
-	}
-}
-
-// applyMiscOptions handles Verbose, Debug, DisableSlashCommands options
-func (r *PodmanRunner) applyMiscOptions(b *claude.CommandBuilder, opts types.ClaudeOptions) {
-	if opts.Verbose {
-		b.WithVerbose()
-	}
-	if opts.Debug != "" {
-		b.WithDebug(opts.Debug)
-	}
-	if opts.DisableSlashCommands {
-		b.WithDisableSlashCommands()
-	}
-}
+// applyClaudeOptions and its sub-appliers were lifted into
+// internal/claude/options.go (claude.ApplyOptions) so the persistent-agent
+// path in cmd/stromboli can share the exact same translation. Keep using
+// claude.ApplyOptions(builder, opts) at every callsite.
 
 // generateRunID creates a unique run ID
 func generateRunID() string {


### PR DESCRIPTION
## Summary

The \`/agents\` endpoint shipped in v0.5.0-alpha but had never been exercised end-to-end. Discovered while running an interactive smoke test: spawning an agent always ended in \`signal: killed\` or \`exit status 1\`, with no transcript to debug from. Five distinct bugs in the spawn path, plus a sixth gap that was suppressing the visible symptoms — Claude options were being parsed off the wire and dropped on the floor.

## The five lifecycle bugs

| # | Bug | Symptom | Fix |
|---|---|---|---|
| 1 | Session subdir not pre-created | \`statfs ...: no such file or directory\`, agent exits with \`signal: killed\` immediately | \`os.MkdirAll(sessionDir, 0700)\` in \`buildAgentArgv\` |
| 2 | Process bound to HTTP request context | Agent SIGKILLed the instant \`POST /agents\` returned 201 (request context cancelled → \`exec.CommandContext\` killed child) | Spawn uses \`context.Background()\`; agent lifetime owned by Manager.Stop / StopAll / watchIdle |
| 3 | Missing \`claude\` prepend | Image entrypoint passed our flags to \`node\` instead; \`node: bad option: --input-format\` | Name \`claude\` explicitly as the in-container binary, mirroring the regular \`/run\` runner |
| 4 | Container ran as root | Claude refuses \`--dangerously-skip-permissions\` for root | Added \`--userns=keep-id\` + \`--user $UID:$GID\` |
| 5 | \`--verbose\` missing | Claude prints \`When using --print, --output-format=stream-json requires --verbose\` and exits 1 | Pinned \`--verbose\` |

## The sixth gap (the option-threading refactor)

\`req.Claude\` was deserialized into \`agent.CreateRequest\` but \`buildAgentArgv\` never read it. Operators sending \`claude.model\`, \`claude.effort\`, \`claude.allowed_tools\`, \`claude.prompt_caching_ttl\`, etc. to \`/agents\` got the CLI's defaults, while the same fields worked fine on \`/run\`. Refactor:

- Extracted \`PodmanRunner.applyClaudeOptions\` and \`applyClaudeEnvVars\` into package-level helpers in \`internal/claude\` (\`claude.ApplyOptions\` and \`claude.EnvVars\`). They had no receiver-state dependence — relocation is pure, no behavior change for \`/run\`.
- \`cmd/stromboli/buildAgentArgv\` uses the same helpers, so \`/agents\` produces the same argv shape (and \`-e\` env injections) that \`/run\` does.
- Three flags are pinned regardless of user input: \`--input-format\` (\`stream-json\`), \`--output-format\` (\`stream-json\`), \`--verbose\`. The agent dispatcher reads stdout line-by-line as JSON; flipping output to \`text\` would silently break every subscriber.

## Tests

Two new test files. The bugs above can't reach main again:

- **\`internal/claude/options_test.go\`** — per-field coverage of the new helpers (model, effort, permissions, tools, budget/turns pointer semantics, prompt-cache TTL recognised values, Bedrock tier, PowerShell tool, all-at-once, empty).
- **\`cmd/stromboli/main_test.go\`** — per-bug regression tests for \`buildAgentArgv\`:
  - rejects an un-creatable session dir
  - \`claude\` prepend is present
  - \`--userns=keep-id\` + \`--user UID:GID\` are present
  - \`--verbose\` is present
  - \`--input-format\` / \`--output-format\` pinned to \`stream-json\` **even when the caller requests \"text\"/\"json\"**
  - \`-w\` lands before the image (it's a podman flag)
  - Claude options thread through to the argv (\`--model\`, \`--effort\`, \`--system-prompt\`, etc.)
  - Env-var-only options reach podman \`-e\`

19/19 packages green on \`go test ./...\`.

## Validated end-to-end

- Spawned a triage agent with a custom system prompt
- \`tail -F\` on a fake server log
- Each appended line forwarded as \`POST /agents/<id>/send\`
- Agent classified each line as \`INFO\`/\`WARN\`/\`CRITICAL\` with reasoning
- 5 lines, 6 turns total (1 boot + 5 events), single warm container
- Triage was accurate: \`WARN\` for slow DB, \`CRITICAL\` for panic + OOM, \`INFO\` for healthy traffic + good cache ratio

## Known gap (separate scope)

\`GET /sessions/{id}/messages\` does not return agent transcripts. Claude's CLI in stream-json mode runs in print mode which is intentionally ephemeral — events flow live via SSE only, nothing is persisted to \`.claude/projects/<encoded-cwd>/<session>.jsonl\`. Operators relying on transcript replay should subscribe to \`GET /agents/{id}/stream\` instead.

A follow-up could add stromboli-side event capture writing the JSONL shape the history reader expects. Tracked separately rather than rolled into this PR — the live SSE flow is the canonical interface for the agent's primary use case (real-time event-driven workloads).

## Test plan

- [x] \`go test ./...\` passes (golang:1.26 in podman)
- [x] Manually spawned and exercised a real persistent agent end-to-end
- [x] Real-time log triage demo (5 lines → 5 verdicts) works
- [ ] CI green on this PR
- [ ] Open follow-up issue for the transcript-capture gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)