### PR TITLE
ci: switch SDK fan-out auth from PAT to GitHub App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,11 +215,22 @@ jobs:
   # The protocol is documented in docs/development/sdk-contract.md —
   # event_type=stromboli-released, client_payload={version, swagger_url}.
   #
-  # Requires a repo secret `SDK_DISPATCH_TOKEN`: a PAT (or GitHub App
-  # token) with `repo` scope on every target. Without it the step skips
-  # gracefully — the release itself still succeeds. New SDK repos are
-  # added by extending the matrix; new ecosystems just need to ship the
-  # template workflow from sdk-contract.md.
+  # Auth model: a GitHub App ("Stromboli SDK Sync") is installed on every
+  # SDK repo with `Contents: Write` permission. We mint a fresh
+  # installation token PER MATRIX ITERATION, scoped to the single SDK
+  # repo we're about to dispatch to — so a leaked token from one job
+  # can only write to that one repo, not the whole fleet. App-based auth
+  # also avoids the PAT-rotation toil and ties the bot identity to the
+  # org rather than a personal account.
+  #
+  # Two secrets required:
+  #   - SDK_DISPATCH_APP_ID         — the App's numeric ID
+  #   - SDK_DISPATCH_APP_PRIVATE_KEY — its PEM-encoded private key
+  #
+  # Without them the step skips gracefully — the release itself still
+  # succeeds. New SDK repos are added by extending the matrix AND
+  # installing the App on the new repo; new ecosystems just need to ship
+  # the template workflow from sdk-contract.md.
   notify-sdks:
     name: Notify SDK repos of release
     needs: release
@@ -234,22 +245,33 @@ jobs:
           - mcp-server-stromboli
           - n8n-nodes-stromboli
     steps:
-      - name: Skip if dispatch token is missing
+      - name: Skip if App credentials are missing
         id: gate
         env:
-          DISPATCH_TOKEN: ${{ secrets.SDK_DISPATCH_TOKEN }}
+          APP_ID: ${{ secrets.SDK_DISPATCH_APP_ID }}
+          APP_KEY: ${{ secrets.SDK_DISPATCH_APP_PRIVATE_KEY }}
         run: |
-          if [ -z "$DISPATCH_TOKEN" ]; then
-            echo "::warning::SDK_DISPATCH_TOKEN secret not configured — skipping fanout. Add a PAT with repo scope to enable."
+          if [ -z "$APP_ID" ] || [ -z "$APP_KEY" ]; then
+            echo "::warning::SDK_DISPATCH_APP_ID / SDK_DISPATCH_APP_PRIVATE_KEY not configured — skipping fanout. See docs/development/sdk-contract.md for setup."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Mint installation token scoped to ${{ matrix.repo }}
+        if: steps.gate.outputs.skip != 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SDK_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.SDK_DISPATCH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ matrix.repo }}
+
       - name: Dispatch stromboli-released event to ${{ matrix.repo }}
         if: steps.gate.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.SDK_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ github.ref_name }}
           REPO: ${{ matrix.repo }}
           OWNER: ${{ github.repository_owner }}

--- a/docs/development/sdk-contract.md
+++ b/docs/development/sdk-contract.md
@@ -126,18 +126,49 @@ jobs:
           labels: stromboli-sync, automated
 ```
 
-## Required repo secret
+## Auth: a GitHub App, not a PAT
 
-The fan-out job in this repo needs a token with `repo` scope on every target SDK. Two ways to provision:
+The fan-out needs cross-repo write access (one `repository_dispatch` per SDK). `GITHUB_TOKEN` is scoped to the source repo and can't do that. We use a **GitHub App** rather than a Personal Access Token because:
 
-| Option | Pros | Cons |
-|---|---|---|
-| **Personal Access Token** (classic, `repo` scope, stored as `SDK_DISPATCH_TOKEN`) | Simple, works today | Tied to a single account; expires |
-| **GitHub App** with `actions: write` + `metadata: read` on each SDK repo, generate an installation token at job time | Auditable, tied to the org | More setup; needs a small token-mint step |
+- **Per-iteration scoping.** The matrix mints a fresh installation token *per SDK repo*, valid only for that one repo. A token leaked from one job can dispatch to that one SDK, not the entire fleet.
+- **No personal-account dependency.** PATs die when their owner leaves; an App is org-owned and survives.
+- **Auditable.** App actions appear under the bot identity in audit logs, not as a human user.
+- **No expiry to rotate.** Installation tokens auto-expire after ~1 hour — but we mint them at job time, so there's nothing to rotate.
 
-Start with a PAT (`Settings → Secrets and variables → Actions → New repository secret`, name `SDK_DISPATCH_TOKEN`). Move to a GitHub App if/when secret rotation becomes a chore.
+### One-time setup
 
-If the secret is missing, the fan-out step **logs a warning and skips** — the release itself never fails because of the SDK side. That's deliberate: a release should never block on downstream tooling, only notify it.
+1. **Create the App** — `Settings → Developer settings → GitHub Apps → New GitHub App`.
+   - Name: `Stromboli SDK Sync` (anything; appears as the actor on dispatched events)
+   - Homepage URL: this repo
+   - Webhook: not needed (uncheck Active)
+   - **Repository permissions:** `Contents: Read and write` (this is what `repository_dispatch` requires)
+   - **Where can this GitHub App be installed?**: Only on this account (or the org if multi-account)
+
+2. **Generate a private key** — on the App's settings page, scroll to "Private keys" → "Generate a private key". Saves a `.pem` file.
+
+3. **Install the App on each SDK repo** — `Install App` from the App's page → select `stromboli-go`, `stromboli-ts`, `mcp-server-stromboli`, `n8n-nodes-stromboli`. Add new SDKs to the install list whenever the matrix grows.
+
+4. **Add two secrets to this repo** — `Settings → Secrets and variables → Actions → New repository secret`:
+   - `SDK_DISPATCH_APP_ID` — the App's numeric ID (visible at the top of its settings page)
+   - `SDK_DISPATCH_APP_PRIVATE_KEY` — paste the entire contents of the `.pem` file, including `-----BEGIN ...` / `-----END ...` lines
+
+### Verify
+
+After the secrets are set, you don't have to wait for a real release — push a no-op tag (e.g. `v0.5.X-alpha-rc1`) and watch the `notify-sdks` matrix in the release workflow. Each iteration should:
+
+1. Skip the gate (because secrets are present)
+2. Mint an installation token via `actions/create-github-app-token@v1`
+3. POST a dispatch to the matrix repo
+
+Then check the SDK's Actions tab — the receiver workflow should fire and open a sync PR.
+
+### Falling back gracefully
+
+If `SDK_DISPATCH_APP_ID` or `SDK_DISPATCH_APP_PRIVATE_KEY` is missing, the fan-out step **logs a warning and skips** — the release itself never fails because of the SDK side. That's deliberate: a release should never block on downstream tooling, only notify it.
+
+### Why not a PAT?
+
+It works as an escape hatch for solo / personal projects, but for "official SDK" coupling the App is strictly better. If you really want a PAT-only setup, the receiver template doesn't change — just swap the App-token-minting step on the server side for a `secrets.SDK_DISPATCH_TOKEN` env. Don't expect long-term peace, though: classic PATs expire, broad scopes are a liability, and personal-account links break things you didn't expect.
 
 ## Compatibility marker
 


### PR DESCRIPTION
## Summary

You said \"these are official SDKs, let it be auto push\" — agreed, push-based is the right call for tightly-coupled SDKs. But the PAT setup #104 introduced has real downsides for an org-grade integration: tied to a personal account, expires, broad \`repo\` scope across every SDK in one credential.

This PR swaps the auth model for a GitHub App. Same observable behaviour (push on tag, fan-out to four SDK repos), better security posture, less rotation toil.

## Why App over PAT

| | PAT | GitHub App |
|---|---|---|
| Scope | One token, broad \`repo\` access on all 4 SDK repos | Per-iteration token, scoped to one SDK repo at a time |
| Identity | Personal account | Org-owned bot |
| Survives owner leaving the org | ❌ | ✅ |
| Audit trail | Appears as the human user | Appears as the App |
| Rotation | Manual, with expiry to track | Auto — installation tokens expire after ~1h, minted fresh each job |
| Setup effort | 2 minutes | 5 minutes |

The biggest win is **per-iteration scoping**. The matrix now mints a fresh token per SDK using \`actions/create-github-app-token@v1\` with \`repositories: \${{ matrix.repo }}\`. A leaked token from one job can dispatch to that one SDK — not the whole fleet.

## Operator setup

Two secrets replace the single PAT:

- \`SDK_DISPATCH_APP_ID\` — numeric App ID
- \`SDK_DISPATCH_APP_PRIVATE_KEY\` — PEM-encoded private key

The full step-by-step (App creation, permissions, installation on each SDK, secret entry) is in [\`docs/development/sdk-contract.md\`](https://github.com/tomblancdev/stromboli/blob/ci/sdk-fanout-via-github-app/docs/development/sdk-contract.md#auth-a-github-app-not-a-pat).

## SDK side: nothing changes

The receiver workflow template doesn't move — SDKs still listen on \`repository_dispatch\` with \`event_type=stromboli-released\`. Auth is purely a server-side concern; what arrives at the SDK looks identical.

## Graceful skip preserved

Same warn-and-skip path: if either secret is missing, the \`notify-sdks\` step logs a warning and exits 0. A release never fails because of downstream tooling.

## Test plan

- [x] YAML lint clean
- [ ] CI green
- [ ] After merge: create the App, install on the 4 SDK repos, add the two secrets, push a no-op tag (e.g. v0.5.5-alpha) — confirm each matrix iteration mints a token and dispatches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)