### PR TITLE
release: cut [0.5.5-alpha] changelog section

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,19 @@ _(empty — add new entries here as PRs land)_
 
 ---
 
+## [0.5.5-alpha] - 2026-05-01
+
+### Added
+
+- **[SDKs & Integrations](sdks.md) page** — landing page for the four official client libraries (`stromboli-go`, `stromboli-ts`, `mcp-server-stromboli`, `n8n-nodes-stromboli`) with a "picking the right one" guide, version-compatibility notes, and a "build your own" pointer to the OpenAPI spec + receiver-workflow template. (#107)
+
+### Documentation
+
+- Home page (`docs/index.md`) gets a "Talk to it from your stack" section linking each SDK; until now the docs talked about the API surface as if everyone would hit it via curl. (#107)
+- Top-level `README.md` shows the SDKs table near the top of the GitHub landing page so it's visible without scrolling. (#107)
+
+---
+
 ## [0.5.4-alpha] - 2026-05-01
 
 ### Added


### PR DESCRIPTION
Release-prep PR for **v0.5.5-alpha**. One PR since v0.5.4 — #107, the SDKs landing page.

**This is the first release after `SDK_DISPATCH_TOKEN` was provisioned**, so the `notify-sdks` job should now fire actual `repository_dispatch` events to each SDK repo this time (instead of the warn-and-skip path v0.5.4 hit). The dispatches will sit unhandled at the SDK side until their receiver workflows are added — but the Actions tab on each SDK repo should now show `stromboli-released` events arriving.

After merge:

```bash
git tag v0.5.5-alpha
git push origin v0.5.5-alpha
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)