### PR TITLE
fix(ci): drop unpublished n8n-nodes-stromboli from fan-out matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,8 @@ jobs:
           - stromboli-go
           - stromboli-ts
           - mcp-server-stromboli
-          - n8n-nodes-stromboli
+          # TODO: re-enable n8n-nodes-stromboli once the repo is published
+          # to GitHub. Currently local-only — dispatch fan-out 404s without it.
     steps:
       - name: Skip if dispatch token is missing
         id: gate

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Official client libraries that track this server's OpenAPI spec automatically â€
 | **Go** | [tomblancdev/stromboli-go](https://github.com/tomblancdev/stromboli-go) | Spawn agents from Go services / CLIs |
 | **TypeScript / JS** | [tomblancdev/stromboli-ts](https://github.com/tomblancdev/stromboli-ts) | Node, Bun, Deno, browsers |
 | **MCP** | [tomblancdev/mcp-server-stromboli](https://github.com/tomblancdev/mcp-server-stromboli) | Let Claude Desktop / Cursor spawn Stromboli agents directly |
-| **n8n** | [tomblancdev/n8n-nodes-stromboli](https://github.com/tomblancdev/n8n-nodes-stromboli) | Drop Stromboli into low-code n8n workflows |
+| **n8n** | _coming soon â€” not yet published_ | Drop Stromboli into low-code n8n workflows |
 
 Building your own SDK? See the [SDK contract page](https://tomblancdev.github.io/stromboli/development/sdk-contract/) for the OpenAPI source of truth and the auto-regen receiver template.
 

--- a/docs/development/sdk-contract.md
+++ b/docs/development/sdk-contract.md
@@ -1,6 +1,6 @@
 # SDK Contract & Release Fan-out
 
-This page describes how downstream client SDKs (`stromboli-go`, `stromboli-ts`, `mcp-server-stromboli`, `n8n-nodes-stromboli`, …) stay in sync with the server's OpenAPI surface.
+This page describes how downstream client SDKs (`stromboli-go`, `stromboli-ts`, `mcp-server-stromboli`, and the upcoming `n8n-nodes-stromboli`) stay in sync with the server's OpenAPI surface.
 
 The contract is intentionally one-way: when a tag is pushed on this repo, a `repository_dispatch` fires to each registered SDK. The SDK receives the new spec, regenerates its typed client, and opens a PR titled `chore: sync to stromboli vX.Y.Z`. If the SDK's own CI passes, the PR can auto-merge. No human in the loop unless the regeneration introduces an actual breaking change.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,7 +103,7 @@ Pick the [SDK or integration](sdks.md) that fits your runtime — all four track
 - [**stromboli-go**](https://github.com/tomblancdev/stromboli-go) — idiomatic Go client
 - [**stromboli-ts**](https://github.com/tomblancdev/stromboli-ts) — TypeScript / JavaScript SDK
 - [**mcp-server-stromboli**](https://github.com/tomblancdev/mcp-server-stromboli) — MCP server for Claude Desktop / Cursor / any MCP client
-- [**n8n-nodes-stromboli**](https://github.com/tomblancdev/n8n-nodes-stromboli) — n8n community node
+- **n8n-nodes-stromboli** — n8n community node _(coming soon)_
 
 Or hit the [REST API](api/endpoints.md) directly — it's just HTTP + JSON.
 

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -34,15 +34,11 @@ All four are kept in sync with the server's OpenAPI spec via the [release fan-ou
 
     [:octicons-mark-github-16: tomblancdev/mcp-server-stromboli](https://github.com/tomblancdev/mcp-server-stromboli)
 
-- :material-graph: **n8n-nodes-stromboli**
+- :material-graph: **n8n-nodes-stromboli** _(coming soon)_
 
     Community node for [n8n](https://n8n.io). Drop Stromboli into your no-code workflows: trigger agent runs from webhooks, chain them with database / messaging / API nodes, route output to Slack / Discord / email.
 
-    [:octicons-mark-github-16: tomblancdev/n8n-nodes-stromboli](https://github.com/tomblancdev/n8n-nodes-stromboli)
-
-    ```bash
-    npm install n8n-nodes-stromboli
-    ```
+    Not yet published to GitHub or the n8n community-nodes registry. Will be added to the [release fan-out](development/sdk-contract.md) once it ships.
 
 </div>
 
@@ -53,7 +49,7 @@ All four are kept in sync with the server's OpenAPI spec via the [release fan-ou
 | Spawn Stromboli agents from a Go service | [stromboli-go](https://github.com/tomblancdev/stromboli-go) |
 | Build a Node / Bun / browser frontend that talks to Stromboli | [stromboli-ts](https://github.com/tomblancdev/stromboli-ts) |
 | Let your editor agent (Claude Desktop, Cursor) spawn Stromboli agents directly | [mcp-server-stromboli](https://github.com/tomblancdev/mcp-server-stromboli) |
-| Wire Stromboli into an n8n workflow alongside other automations | [n8n-nodes-stromboli](https://github.com/tomblancdev/n8n-nodes-stromboli) |
+| Wire Stromboli into an n8n workflow alongside other automations | n8n-nodes-stromboli _(coming soon)_ |
 | Stay protocol-agnostic / hit the API from a language without an SDK | The [REST API](api/endpoints.md) is just HTTP + JSON; any HTTP client works |
 
 ## Version compatibility


### PR DESCRIPTION
## Summary

The v0.5.5-alpha release surfaced that **n8n-nodes-stromboli is local-only** — it's never been pushed to GitHub, so the fan-out's matrix iteration for it 404'd:

```
gh: Not Found (HTTP 404)
{"message":"Not Found",
 "documentation_url":"https://docs.github.com/rest/repos/repos#create-a-repository-dispatch-event"}
```

## What this PR does

- **Removes `n8n-nodes-stromboli` from the `notify-sdks` matrix** with a TODO comment so it can be re-added in one line once the repo is published.
- **Marks it 'coming soon' in the docs** so we don't link to a 404:
  - `docs/sdks.md` card: "coming soon", no link
  - `docs/sdks.md` picking-by-runtime table: same
  - `docs/index.md` home-page list: link removed
  - `README.md` SDKs table: link removed
  - `docs/development/sdk-contract.md` intro: notes upcoming status

## What v0.5.5 proved

Three of four SDKs **received their dispatches successfully** — the PAT auth wiring works end-to-end. Confirm by checking each repo's Actions tab:

- ✅ https://github.com/tomblancdev/stromboli-go/actions
- ✅ https://github.com/tomblancdev/stromboli-ts/actions
- ✅ https://github.com/tomblancdev/mcp-server-stromboli/actions

(The dispatches will sit unhandled until receiver workflows are added on each SDK side, but the events themselves should be visible in the Actions list.)

## Test plan

- [x] YAML lint clean
- [ ] CI green
- [ ] After merge: cut a no-op v0.5.6-alpha to verify all 3 remaining matrix entries succeed without the n8n entry tripping the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)