### PR TITLE
release: cut [0.5.6-alpha] changelog section

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,22 @@ _(empty — add new entries here as PRs land)_
 
 ---
 
+## [0.5.6-alpha] - 2026-05-01
+
+### Fixed
+
+- **`notify-sdks` fan-out no longer 404s on n8n.** v0.5.5-alpha surfaced that `n8n-nodes-stromboli` is a local-only repo and has never been pushed to GitHub — its matrix iteration failed with HTTP 404 and propagated up to mark the whole release run as failed (the GitHub release artefacts still landed correctly). Removed it from the matrix with a TODO comment so it can be re-added in one line once the repo is published. (#109)
+
+### Documentation
+
+- `n8n-nodes-stromboli` is now marked "coming soon" everywhere it appears (home page, SDKs page, README, sdk-contract intro) — no broken links to a non-existent GitHub URL. (#109)
+
+### Ecosystem
+
+- **First receiver workflow landed on `stromboli-go`** ([tomblancdev/stromboli-go#22](https://github.com/tomblancdev/stromboli-go/pull/22)). It listens on the `stromboli-released` dispatch (and `workflow_dispatch` for manual triggering), records the version to `STROMBOLI_COMPAT`, and opens a `chore: sync to stromboli vX.Y.Z` PR. Codegen is intentionally TODO — the point of landing the minimal receiver now is to make the dispatch path observable in the Actions tab, where unhandled `repository_dispatch` events leave no trace.
+
+---
+
 ## [0.5.5-alpha] - 2026-05-01
 
 ### Added


### PR DESCRIPTION
Release-prep PR for **v0.5.6-alpha**.

Two PRs since v0.5.5:

- **#109** drops the unpublished `n8n-nodes-stromboli` from the `notify-sdks` matrix.
- **[tomblancdev/stromboli-go#22](https://github.com/tomblancdev/stromboli-go/pull/22)** landed the first receiver workflow, so dispatches arriving at `stromboli-go` will now produce visible workflow runs in the Actions tab.

This release is the **first end-to-end demo of the dispatch path**: when the tag pushes, stromboli's `notify-sdks` should fire three successful dispatches (no more n8n 404), stromboli-go's receiver picks its dispatch up and opens a `chore: sync to stromboli v0.5.6-alpha` PR there. The other two SDKs (stromboli-ts, mcp-server-stromboli) silently drop the events until they get receivers of their own.

After merge:

```bash
git tag v0.5.6-alpha
git push origin v0.5.6-alpha
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)