### PR TITLE
release: cut [0.5.7-alpha] changelog section

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,19 @@ _(empty — add new entries here as PRs land)_
 
 ---
 
+## [0.5.7-alpha] - 2026-05-06
+
+### Documentation
+
+- **Receiver workflow template hardened** in response to two real-world failures found while landing the first receiver on `stromboli-go`: (1) the cross-repo release lookup now uses `curl` against the public REST API instead of `gh release view --repo`, which 404s because `GITHUB_TOKEN` in the SDK runner is scoped to its own repo; (2) it hits `/releases` (plural) instead of `/releases/latest`, which 404s on a repo that only ships `-alpha` / `-beta` tags. An inline warning calls out the repo-level "Allow GitHub Actions to create and approve pull requests" toggle, which the receiver workflow needs even with `pull-requests: write`. (#111)
+
+### Dependencies
+
+- `google.golang.org/grpc` 1.80.0 → 1.81.0 — bug fixes in xDS resource validation and HTTP/2 stream handling; pool HTTP/2 framer read buffers to reduce idle memory consumption (Linux ALTS + non-encrypted transports). New experimental SNI/SAN validation behind `GRPC_EXPERIMENTAL_XDS_SNI`. Minimum Go version raised to 1.25 (already met). (#112)
+- GitHub Actions group bumps moving runners from the deprecated Node 20 to Node 24: `docker/setup-buildx-action` v3 → v4, `docker/build-push-action` v6 → v7, `golangci/golangci-lint-action` v8 → v9. Requires Actions Runner v2.327.1+. (#113)
+
+---
+
 ## [0.5.6-alpha] - 2026-05-01
 
 ### Fixed


### PR DESCRIPTION
Release-prep PR for **v0.5.7-alpha**.

Three PRs since v0.5.6:

- **#111** — polished the SDK receiver workflow template (cross-repo REST lookup, prerelease-only `/releases` form, and the "Allow Actions to create PRs" repo setting note). All three were real failures hit while landing the first receiver on `stromboli-go`.
- **#112** — bumped `google.golang.org/grpc` 1.80 → 1.81. Min Go 1.25, already met.
- **#113** — bumped the actions group (`docker/setup-buildx-action` v3→v4, `docker/build-push-action` v6→v7, `golangci/golangci-lint-action` v8→v9) — all major bumps moving GHA runners off the deprecated Node 20 onto Node 24.

Receiver smoke test: when the tag pushes, stromboli's `notify-sdks` should fan out three `repository_dispatch`es; `stromboli-go`'s receiver — now using the hardened template merged in #111 — picks up its dispatch and opens a `chore: sync to stromboli v0.5.7-alpha` PR there. The other two SDKs (`stromboli-ts`, `mcp-server-stromboli`) silently drop the events until they get receivers of their own.

After merge:

\`\`\`bash
git tag v0.5.7-alpha
git push origin v0.5.7-alpha
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)